### PR TITLE
Filter example common dependencies

### DIFF
--- a/java/example/calypso/pc/Demo_CalypsoClassic/src/main/java/org/eclipse/keyple/example/common
+++ b/java/example/calypso/pc/Demo_CalypsoClassic/src/main/java/org/eclipse/keyple/example/common
@@ -1,1 +1,0 @@
-../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/

--- a/java/example/calypso/pc/Demo_CalypsoClassic/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java
+++ b/java/example/calypso/pc/Demo_CalypsoClassic/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java

--- a/java/example/calypso/pc/Demo_CalypsoClassic/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java
+++ b/java/example/calypso/pc/Demo_CalypsoClassic/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java

--- a/java/example/calypso/pc/Demo_CalypsoClassic/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoClassicTransactionEngine.java
+++ b/java/example/calypso/pc/Demo_CalypsoClassic/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoClassicTransactionEngine.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoClassicTransactionEngine.java

--- a/java/example/calypso/pc/Demo_CalypsoClassic/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoUtilities.java
+++ b/java/example/calypso/pc/Demo_CalypsoClassic/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoUtilities.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoUtilities.java

--- a/java/example/calypso/pc/Demo_CalypsoClassic/src/main/java/org/eclipse/keyple/example/common/calypso/postructure/CalypsoClassicInfo.java
+++ b/java/example/calypso/pc/Demo_CalypsoClassic/src/main/java/org/eclipse/keyple/example/common/calypso/postructure/CalypsoClassicInfo.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/calypso/postructure/CalypsoClassicInfo.java

--- a/java/example/calypso/pc/Demo_CalypsoClassic/src/main/java/org/eclipse/keyple/example/common/calypso/stub/StubCalypsoClassic.java
+++ b/java/example/calypso/pc/Demo_CalypsoClassic/src/main/java/org/eclipse/keyple/example/common/calypso/stub/StubCalypsoClassic.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/calypso/stub/StubCalypsoClassic.java

--- a/java/example/calypso/pc/Demo_CalypsoClassic/src/main/java/org/eclipse/keyple/example/common/calypso/stub/StubSamCalypsoClassic.java
+++ b/java/example/calypso/pc/Demo_CalypsoClassic/src/main/java/org/eclipse/keyple/example/common/calypso/stub/StubSamCalypsoClassic.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/calypso/stub/StubSamCalypsoClassic.java

--- a/java/example/calypso/pc/Demo_CalypsoClassic/src/main/java/org/eclipse/keyple/example/common/generic/AbstractReaderObserverEngine.java
+++ b/java/example/calypso/pc/Demo_CalypsoClassic/src/main/java/org/eclipse/keyple/example/common/generic/AbstractReaderObserverEngine.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/generic/AbstractReaderObserverEngine.java

--- a/java/example/calypso/pc/UseCase_Calypso1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/common
+++ b/java/example/calypso/pc/UseCase_Calypso1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/common
@@ -1,1 +1,0 @@
-../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/

--- a/java/example/calypso/pc/UseCase_Calypso1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java
+++ b/java/example/calypso/pc/UseCase_Calypso1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java

--- a/java/example/calypso/pc/UseCase_Calypso1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java
+++ b/java/example/calypso/pc/UseCase_Calypso1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java

--- a/java/example/calypso/pc/UseCase_Calypso1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoUtilities.java
+++ b/java/example/calypso/pc/UseCase_Calypso1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoUtilities.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoUtilities.java

--- a/java/example/calypso/pc/UseCase_Calypso1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/common/calypso/postructure/CalypsoClassicInfo.java
+++ b/java/example/calypso/pc/UseCase_Calypso1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/common/calypso/postructure/CalypsoClassicInfo.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/calypso/postructure/CalypsoClassicInfo.java

--- a/java/example/calypso/pc/UseCase_Calypso1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/common/calypso/stub/StubCalypsoClassic.java
+++ b/java/example/calypso/pc/UseCase_Calypso1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/common/calypso/stub/StubCalypsoClassic.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/calypso/stub/StubCalypsoClassic.java

--- a/java/example/calypso/pc/UseCase_Calypso2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/common
+++ b/java/example/calypso/pc/UseCase_Calypso2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/common
@@ -1,1 +1,0 @@
-../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/

--- a/java/example/calypso/pc/UseCase_Calypso2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java
+++ b/java/example/calypso/pc/UseCase_Calypso2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java

--- a/java/example/calypso/pc/UseCase_Calypso2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java
+++ b/java/example/calypso/pc/UseCase_Calypso2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java

--- a/java/example/calypso/pc/UseCase_Calypso2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoUtilities.java
+++ b/java/example/calypso/pc/UseCase_Calypso2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoUtilities.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoUtilities.java

--- a/java/example/calypso/pc/UseCase_Calypso2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/common/calypso/postructure/CalypsoClassicInfo.java
+++ b/java/example/calypso/pc/UseCase_Calypso2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/common/calypso/postructure/CalypsoClassicInfo.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/calypso/postructure/CalypsoClassicInfo.java

--- a/java/example/calypso/pc/UseCase_Calypso2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/common/calypso/stub/StubCalypsoClassic.java
+++ b/java/example/calypso/pc/UseCase_Calypso2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/common/calypso/stub/StubCalypsoClassic.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/calypso/stub/StubCalypsoClassic.java

--- a/java/example/calypso/pc/UseCase_Calypso3_Rev1Selection/build.gradle
+++ b/java/example/calypso/pc/UseCase_Calypso3_Rev1Selection/build.gradle
@@ -23,7 +23,6 @@ dependencies {
     implementation group: 'org.eclipse.keyple', name: 'keyple-java-core', version: '+'
     implementation group: 'org.eclipse.keyple', name: 'keyple-java-calypso', version: '+'
     implementation group: 'org.eclipse.keyple', name: 'keyple-java-plugin-pcsc', version: '+'
-    implementation group: 'org.eclipse.keyple', name: 'keyple-java-plugin-stub', version: '+'
 
     implementation "org.slf4j:slf4j-simple:1.7.25"
     implementation "org.slf4j:slf4j-ext:1.7.25"

--- a/java/example/calypso/pc/UseCase_Calypso3_Rev1Selection/src/main/java/org/eclipse/keyple/example/common
+++ b/java/example/calypso/pc/UseCase_Calypso3_Rev1Selection/src/main/java/org/eclipse/keyple/example/common
@@ -1,1 +1,0 @@
-../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/

--- a/java/example/calypso/pc/UseCase_Calypso3_Rev1Selection/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java
+++ b/java/example/calypso/pc/UseCase_Calypso3_Rev1Selection/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java

--- a/java/example/calypso/pc/UseCase_Calypso3_Rev1Selection/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java
+++ b/java/example/calypso/pc/UseCase_Calypso3_Rev1Selection/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java

--- a/java/example/calypso/pc/UseCase_Calypso3_Rev1Selection/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoUtilities.java
+++ b/java/example/calypso/pc/UseCase_Calypso3_Rev1Selection/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoUtilities.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoUtilities.java

--- a/java/example/calypso/pc/UseCase_Calypso3_Rev1Selection/src/main/java/org/eclipse/keyple/example/common/calypso/postructure/CalypsoClassicInfo.java
+++ b/java/example/calypso/pc/UseCase_Calypso3_Rev1Selection/src/main/java/org/eclipse/keyple/example/common/calypso/postructure/CalypsoClassicInfo.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/calypso/postructure/CalypsoClassicInfo.java

--- a/java/example/calypso/pc/UseCase_Calypso4_PoAuthentication/src/main/java/org/eclipse/keyple/example/common
+++ b/java/example/calypso/pc/UseCase_Calypso4_PoAuthentication/src/main/java/org/eclipse/keyple/example/common
@@ -1,1 +1,0 @@
-../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/

--- a/java/example/calypso/pc/UseCase_Calypso4_PoAuthentication/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java
+++ b/java/example/calypso/pc/UseCase_Calypso4_PoAuthentication/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java

--- a/java/example/calypso/pc/UseCase_Calypso4_PoAuthentication/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java
+++ b/java/example/calypso/pc/UseCase_Calypso4_PoAuthentication/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java

--- a/java/example/calypso/pc/UseCase_Calypso4_PoAuthentication/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoUtilities.java
+++ b/java/example/calypso/pc/UseCase_Calypso4_PoAuthentication/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoUtilities.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoUtilities.java

--- a/java/example/calypso/pc/UseCase_Calypso4_PoAuthentication/src/main/java/org/eclipse/keyple/example/common/calypso/postructure/CalypsoClassicInfo.java
+++ b/java/example/calypso/pc/UseCase_Calypso4_PoAuthentication/src/main/java/org/eclipse/keyple/example/common/calypso/postructure/CalypsoClassicInfo.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/calypso/postructure/CalypsoClassicInfo.java

--- a/java/example/calypso/pc/UseCase_Calypso4_PoAuthentication/src/main/java/org/eclipse/keyple/example/common/calypso/stub/StubCalypsoClassic.java
+++ b/java/example/calypso/pc/UseCase_Calypso4_PoAuthentication/src/main/java/org/eclipse/keyple/example/common/calypso/stub/StubCalypsoClassic.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/calypso/stub/StubCalypsoClassic.java

--- a/java/example/calypso/pc/UseCase_Calypso4_PoAuthentication/src/main/java/org/eclipse/keyple/example/common/calypso/stub/StubSamCalypsoClassic.java
+++ b/java/example/calypso/pc/UseCase_Calypso4_PoAuthentication/src/main/java/org/eclipse/keyple/example/common/calypso/stub/StubSamCalypsoClassic.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/calypso/stub/StubSamCalypsoClassic.java

--- a/java/example/calypso/pc/UseCase_Calypso5_MultipleSession/build.gradle
+++ b/java/example/calypso/pc/UseCase_Calypso5_MultipleSession/build.gradle
@@ -23,7 +23,6 @@ dependencies {
     implementation group: 'org.eclipse.keyple', name: 'keyple-java-core', version: '+'
     implementation group: 'org.eclipse.keyple', name: 'keyple-java-calypso', version: '+'
     implementation group: 'org.eclipse.keyple', name: 'keyple-java-plugin-pcsc', version: '+'
-    implementation group: 'org.eclipse.keyple', name: 'keyple-java-plugin-stub', version: '+'
 
     implementation "org.slf4j:slf4j-simple:1.7.25"
     implementation "org.slf4j:slf4j-ext:1.7.25"

--- a/java/example/calypso/pc/UseCase_Calypso5_MultipleSession/src/main/java/org/eclipse/keyple/example/common
+++ b/java/example/calypso/pc/UseCase_Calypso5_MultipleSession/src/main/java/org/eclipse/keyple/example/common
@@ -1,1 +1,0 @@
-../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/

--- a/java/example/calypso/pc/UseCase_Calypso5_MultipleSession/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java
+++ b/java/example/calypso/pc/UseCase_Calypso5_MultipleSession/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java

--- a/java/example/calypso/pc/UseCase_Calypso5_MultipleSession/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java
+++ b/java/example/calypso/pc/UseCase_Calypso5_MultipleSession/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java

--- a/java/example/calypso/pc/UseCase_Calypso5_MultipleSession/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoUtilities.java
+++ b/java/example/calypso/pc/UseCase_Calypso5_MultipleSession/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoUtilities.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoUtilities.java

--- a/java/example/calypso/pc/UseCase_Calypso5_MultipleSession/src/main/java/org/eclipse/keyple/example/common/calypso/postructure/CalypsoClassicInfo.java
+++ b/java/example/calypso/pc/UseCase_Calypso5_MultipleSession/src/main/java/org/eclipse/keyple/example/common/calypso/postructure/CalypsoClassicInfo.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/calypso/postructure/CalypsoClassicInfo.java

--- a/java/example/calypso/remotese/src/main/java/org/eclipse/keyple/example/common
+++ b/java/example/calypso/remotese/src/main/java/org/eclipse/keyple/example/common
@@ -1,1 +1,0 @@
-../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/

--- a/java/example/calypso/remotese/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java
+++ b/java/example/calypso/remotese/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java

--- a/java/example/calypso/remotese/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java
+++ b/java/example/calypso/remotese/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java

--- a/java/example/calypso/remotese/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoUtilities.java
+++ b/java/example/calypso/remotese/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoUtilities.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoUtilities.java

--- a/java/example/calypso/remotese/src/main/java/org/eclipse/keyple/example/common/calypso/postructure/CalypsoClassicInfo.java
+++ b/java/example/calypso/remotese/src/main/java/org/eclipse/keyple/example/common/calypso/postructure/CalypsoClassicInfo.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/calypso/postructure/CalypsoClassicInfo.java

--- a/java/example/calypso/remotese/src/main/java/org/eclipse/keyple/example/common/calypso/stub/StubCalypsoClassic.java
+++ b/java/example/calypso/remotese/src/main/java/org/eclipse/keyple/example/common/calypso/stub/StubCalypsoClassic.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/calypso/stub/StubCalypsoClassic.java

--- a/java/example/calypso/remotese/src/main/java/org/eclipse/keyple/example/common/calypso/stub/StubSamCalypsoClassic.java
+++ b/java/example/calypso/remotese/src/main/java/org/eclipse/keyple/example/common/calypso/stub/StubSamCalypsoClassic.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/calypso/stub/StubSamCalypsoClassic.java

--- a/java/example/generic/pc/Demo_ObservableReaderNotification/build.gradle
+++ b/java/example/generic/pc/Demo_ObservableReaderNotification/build.gradle
@@ -21,7 +21,6 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
 
     implementation group: 'org.eclipse.keyple', name: 'keyple-java-core', version: '+'
-    implementation group: 'org.eclipse.keyple', name: 'keyple-java-calypso', version: '+'
     implementation group: 'org.eclipse.keyple', name: 'keyple-java-plugin-pcsc', version: '+'
     implementation group: 'org.eclipse.keyple', name: 'keyple-java-plugin-stub', version: '+'
 

--- a/java/example/generic/pc/Demo_ObservableReaderNotification/src/main/java/org/eclipse/keyple/example/common
+++ b/java/example/generic/pc/Demo_ObservableReaderNotification/src/main/java/org/eclipse/keyple/example/common
@@ -1,1 +1,0 @@
-../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/

--- a/java/example/generic/pc/Demo_ObservableReaderNotification/src/main/java/org/eclipse/keyple/example/common/generic/ObservableReaderNotificationEngine.java
+++ b/java/example/generic/pc/Demo_ObservableReaderNotification/src/main/java/org/eclipse/keyple/example/common/generic/ObservableReaderNotificationEngine.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/generic/ObservableReaderNotificationEngine.java

--- a/java/example/generic/pc/Demo_ObservableReaderNotification/src/main/java/org/eclipse/keyple/example/common/generic/stub/StubSe1.java
+++ b/java/example/generic/pc/Demo_ObservableReaderNotification/src/main/java/org/eclipse/keyple/example/common/generic/stub/StubSe1.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/generic/stub/StubSe1.java

--- a/java/example/generic/pc/Demo_ObservableReaderNotification/src/main/java/org/eclipse/keyple/example/common/generic/stub/StubSe2.java
+++ b/java/example/generic/pc/Demo_ObservableReaderNotification/src/main/java/org/eclipse/keyple/example/common/generic/stub/StubSe2.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/generic/stub/StubSe2.java

--- a/java/example/generic/pc/Demo_SeProtocolDetection/src/main/java/org/eclipse/keyple/example/common
+++ b/java/example/generic/pc/Demo_SeProtocolDetection/src/main/java/org/eclipse/keyple/example/common
@@ -1,1 +1,0 @@
-../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/

--- a/java/example/generic/pc/Demo_SeProtocolDetection/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java
+++ b/java/example/generic/pc/Demo_SeProtocolDetection/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java

--- a/java/example/generic/pc/Demo_SeProtocolDetection/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java
+++ b/java/example/generic/pc/Demo_SeProtocolDetection/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java

--- a/java/example/generic/pc/Demo_SeProtocolDetection/src/main/java/org/eclipse/keyple/example/common/generic/AbstractReaderObserverEngine.java
+++ b/java/example/generic/pc/Demo_SeProtocolDetection/src/main/java/org/eclipse/keyple/example/common/generic/AbstractReaderObserverEngine.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/generic/AbstractReaderObserverEngine.java

--- a/java/example/generic/pc/Demo_SeProtocolDetection/src/main/java/org/eclipse/keyple/example/common/generic/GenericSeSelectionRequest.java
+++ b/java/example/generic/pc/Demo_SeProtocolDetection/src/main/java/org/eclipse/keyple/example/common/generic/GenericSeSelectionRequest.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/generic/GenericSeSelectionRequest.java

--- a/java/example/generic/pc/Demo_SeProtocolDetection/src/main/java/org/eclipse/keyple/example/common/generic/SeProtocolDetectionEngine.java
+++ b/java/example/generic/pc/Demo_SeProtocolDetection/src/main/java/org/eclipse/keyple/example/common/generic/SeProtocolDetectionEngine.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/generic/SeProtocolDetectionEngine.java

--- a/java/example/generic/pc/Demo_SeProtocolDetection/src/main/java/org/eclipse/keyple/example/common/generic/stub/StubCalypsoBPrime.java
+++ b/java/example/generic/pc/Demo_SeProtocolDetection/src/main/java/org/eclipse/keyple/example/common/generic/stub/StubCalypsoBPrime.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/generic/stub/StubCalypsoBPrime.java

--- a/java/example/generic/pc/Demo_SeProtocolDetection/src/main/java/org/eclipse/keyple/example/common/generic/stub/StubISO14443_4.java
+++ b/java/example/generic/pc/Demo_SeProtocolDetection/src/main/java/org/eclipse/keyple/example/common/generic/stub/StubISO14443_4.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/generic/stub/StubISO14443_4.java

--- a/java/example/generic/pc/Demo_SeProtocolDetection/src/main/java/org/eclipse/keyple/example/common/generic/stub/StubMemoryST25.java
+++ b/java/example/generic/pc/Demo_SeProtocolDetection/src/main/java/org/eclipse/keyple/example/common/generic/stub/StubMemoryST25.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/generic/stub/StubMemoryST25.java

--- a/java/example/generic/pc/Demo_SeProtocolDetection/src/main/java/org/eclipse/keyple/example/common/generic/stub/StubMifareClassic.java
+++ b/java/example/generic/pc/Demo_SeProtocolDetection/src/main/java/org/eclipse/keyple/example/common/generic/stub/StubMifareClassic.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/generic/stub/StubMifareClassic.java

--- a/java/example/generic/pc/Demo_SeProtocolDetection/src/main/java/org/eclipse/keyple/example/common/generic/stub/StubMifareDesfire.java
+++ b/java/example/generic/pc/Demo_SeProtocolDetection/src/main/java/org/eclipse/keyple/example/common/generic/stub/StubMifareDesfire.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/generic/stub/StubMifareDesfire.java

--- a/java/example/generic/pc/Demo_SeProtocolDetection/src/main/java/org/eclipse/keyple/example/common/generic/stub/StubMifareUL.java
+++ b/java/example/generic/pc/Demo_SeProtocolDetection/src/main/java/org/eclipse/keyple/example/common/generic/stub/StubMifareUL.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/generic/stub/StubMifareUL.java

--- a/java/example/generic/pc/Demo_SeProtocolDetection/src/main/java/org/eclipse/keyple/example/common/generic/stub/StubSe1.java
+++ b/java/example/generic/pc/Demo_SeProtocolDetection/src/main/java/org/eclipse/keyple/example/common/generic/stub/StubSe1.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/generic/stub/StubSe1.java

--- a/java/example/generic/pc/Demo_SeProtocolDetection/src/main/java/org/eclipse/keyple/example/common/generic/stub/StubSe2.java
+++ b/java/example/generic/pc/Demo_SeProtocolDetection/src/main/java/org/eclipse/keyple/example/common/generic/stub/StubSe2.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/generic/stub/StubSe2.java

--- a/java/example/generic/pc/README.md
+++ b/java/example/generic/pc/README.md
@@ -32,7 +32,7 @@ Those examples make use of the Keyple Core library. They demonstrate how to obse
   * PO type detection through the use of the protocol flag mechanism [`Demo_SeProtocolDetection`]
     * Real mode with PC/SC readers (Secure Elements required [Calypso and/or others]) [`Demo_SeProtocolDetection_Pcsc.java`]
     * Simulation mode (virtual Secure Elements included) [`Demo_SeProtocolDetection_Stub.java`]
-  * Use case select next: illustrates the possibility of selecting multiple SE applications using the same AID prefix and P2 standard values to select the first or next occurrence. [`UseCase_SelectNext_Pcsc.java`]
+  * Use case multiple select: illustrates the possibility of selecting multiple SE applications using the same AID prefix and P2 standard values to select the first or next occurrence. [`UseCase_Generic4_SequentialMultiSelection.java`]
   
 Available packages in details:
 --

--- a/java/example/generic/pc/UseCase_Generic1_ExplicitSelectionAid/build.gradle
+++ b/java/example/generic/pc/UseCase_Generic1_ExplicitSelectionAid/build.gradle
@@ -21,9 +21,7 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
 
     implementation group: 'org.eclipse.keyple', name: 'keyple-java-core', version: '+'
-    implementation group: 'org.eclipse.keyple', name: 'keyple-java-calypso', version: '+'
     implementation group: 'org.eclipse.keyple', name: 'keyple-java-plugin-pcsc', version: '+'
-    implementation group: 'org.eclipse.keyple', name: 'keyple-java-plugin-stub', version: '+'
 
     implementation "org.slf4j:slf4j-simple:1.7.25"
     implementation "org.slf4j:slf4j-ext:1.7.25"

--- a/java/example/generic/pc/UseCase_Generic1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/common
+++ b/java/example/generic/pc/UseCase_Generic1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/common
@@ -1,1 +1,0 @@
-../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/

--- a/java/example/generic/pc/UseCase_Generic1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java
+++ b/java/example/generic/pc/UseCase_Generic1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java

--- a/java/example/generic/pc/UseCase_Generic1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java
+++ b/java/example/generic/pc/UseCase_Generic1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java

--- a/java/example/generic/pc/UseCase_Generic1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/common/generic/GenericSeSelectionRequest.java
+++ b/java/example/generic/pc/UseCase_Generic1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/common/generic/GenericSeSelectionRequest.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/generic/GenericSeSelectionRequest.java

--- a/java/example/generic/pc/UseCase_Generic2_DefaultSelectionNotification/build.gradle
+++ b/java/example/generic/pc/UseCase_Generic2_DefaultSelectionNotification/build.gradle
@@ -21,9 +21,7 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
 
     implementation group: 'org.eclipse.keyple', name: 'keyple-java-core', version: '+'
-    implementation group: 'org.eclipse.keyple', name: 'keyple-java-calypso', version: '+'
     implementation group: 'org.eclipse.keyple', name: 'keyple-java-plugin-pcsc', version: '+'
-    implementation group: 'org.eclipse.keyple', name: 'keyple-java-plugin-stub', version: '+'
 
     implementation "org.slf4j:slf4j-simple:1.7.25"
     implementation "org.slf4j:slf4j-ext:1.7.25"

--- a/java/example/generic/pc/UseCase_Generic2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/common
+++ b/java/example/generic/pc/UseCase_Generic2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/common
@@ -1,1 +1,0 @@
-../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/

--- a/java/example/generic/pc/UseCase_Generic2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java
+++ b/java/example/generic/pc/UseCase_Generic2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java

--- a/java/example/generic/pc/UseCase_Generic2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java
+++ b/java/example/generic/pc/UseCase_Generic2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java

--- a/java/example/generic/pc/UseCase_Generic2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/common/generic/GenericSeSelectionRequest.java
+++ b/java/example/generic/pc/UseCase_Generic2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/common/generic/GenericSeSelectionRequest.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/generic/GenericSeSelectionRequest.java

--- a/java/example/generic/pc/UseCase_Generic3_GroupedMultiSelection/build.gradle
+++ b/java/example/generic/pc/UseCase_Generic3_GroupedMultiSelection/build.gradle
@@ -21,9 +21,7 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
 
     implementation group: 'org.eclipse.keyple', name: 'keyple-java-core', version: '+'
-    implementation group: 'org.eclipse.keyple', name: 'keyple-java-calypso', version: '+'
     implementation group: 'org.eclipse.keyple', name: 'keyple-java-plugin-pcsc', version: '+'
-    implementation group: 'org.eclipse.keyple', name: 'keyple-java-plugin-stub', version: '+'
 
     implementation "org.slf4j:slf4j-simple:1.7.25"
     implementation "org.slf4j:slf4j-ext:1.7.25"

--- a/java/example/generic/pc/UseCase_Generic3_GroupedMultiSelection/src/main/java/org/eclipse/keyple/example/common
+++ b/java/example/generic/pc/UseCase_Generic3_GroupedMultiSelection/src/main/java/org/eclipse/keyple/example/common
@@ -1,1 +1,0 @@
-../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/

--- a/java/example/generic/pc/UseCase_Generic3_GroupedMultiSelection/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java
+++ b/java/example/generic/pc/UseCase_Generic3_GroupedMultiSelection/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java

--- a/java/example/generic/pc/UseCase_Generic3_GroupedMultiSelection/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java
+++ b/java/example/generic/pc/UseCase_Generic3_GroupedMultiSelection/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java

--- a/java/example/generic/pc/UseCase_Generic3_GroupedMultiSelection/src/main/java/org/eclipse/keyple/example/common/generic/GenericSeSelectionRequest.java
+++ b/java/example/generic/pc/UseCase_Generic3_GroupedMultiSelection/src/main/java/org/eclipse/keyple/example/common/generic/GenericSeSelectionRequest.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/generic/GenericSeSelectionRequest.java

--- a/java/example/generic/pc/UseCase_Generic4_SequentialMultiSelection/build.gradle
+++ b/java/example/generic/pc/UseCase_Generic4_SequentialMultiSelection/build.gradle
@@ -21,9 +21,7 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
 
     implementation group: 'org.eclipse.keyple', name: 'keyple-java-core', version: '+'
-    implementation group: 'org.eclipse.keyple', name: 'keyple-java-calypso', version: '+'
     implementation group: 'org.eclipse.keyple', name: 'keyple-java-plugin-pcsc', version: '+'
-    implementation group: 'org.eclipse.keyple', name: 'keyple-java-plugin-stub', version: '+'
 
     implementation "org.slf4j:slf4j-simple:1.7.25"
     implementation "org.slf4j:slf4j-ext:1.7.25"

--- a/java/example/generic/pc/UseCase_Generic4_SequentialMultiSelection/src/main/java/org/eclipse/keyple/example/common
+++ b/java/example/generic/pc/UseCase_Generic4_SequentialMultiSelection/src/main/java/org/eclipse/keyple/example/common
@@ -1,1 +1,0 @@
-../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/

--- a/java/example/generic/pc/UseCase_Generic4_SequentialMultiSelection/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java
+++ b/java/example/generic/pc/UseCase_Generic4_SequentialMultiSelection/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/PcscReadersSettings.java

--- a/java/example/generic/pc/UseCase_Generic4_SequentialMultiSelection/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java
+++ b/java/example/generic/pc/UseCase_Generic4_SequentialMultiSelection/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/ReaderUtilities.java

--- a/java/example/generic/pc/UseCase_Generic4_SequentialMultiSelection/src/main/java/org/eclipse/keyple/example/common/generic/GenericSeSelectionRequest.java
+++ b/java/example/generic/pc/UseCase_Generic4_SequentialMultiSelection/src/main/java/org/eclipse/keyple/example/common/generic/GenericSeSelectionRequest.java
@@ -1,0 +1,1 @@
+../../../../../../../../../../../../common/src/main/java/org/eclipse/keyple/example/common/generic/GenericSeSelectionRequest.java


### PR DESCRIPTION
All unused common dependencies have been removed from each project
--> each single example is now linked to the dependencies which are actually necessary.

Also, dependencies in the gradle configuration have been cleaned accordingly.