### PR TITLE
bug/keyp-212 : use a configurable executorService for keyple Dto send()

### DIFF
--- a/java/component/keyple-core/src/test/java/org/eclipse/keyple/core/seproxy/plugin/AbstractPluginTest.java
+++ b/java/component/keyple-core/src/test/java/org/eclipse/keyple/core/seproxy/plugin/AbstractPluginTest.java
@@ -11,6 +11,7 @@
  ********************************************************************************/
 package org.eclipse.keyple.core.seproxy.plugin;
 
+import java.util.NoSuchElementException;
 import java.util.SortedSet;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
@@ -33,14 +34,12 @@ public class AbstractPluginTest extends CoreBaseTest {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractPluginTest.class);
 
-    static final Integer X_TIMES = 10; // run tests multiple times
+    static final Integer X_TIMES = 50; // run tests multiple times
 
     @Parameterized.Parameters
     public static Object[][] data() {
         return new Object[X_TIMES][0];
     }
-
-
 
     @Before
     public void setUp() {
@@ -108,12 +107,14 @@ public class AbstractPluginTest extends CoreBaseTest {
         Thread thread = new Thread() {
             public void run() {
                 for (int i = 0; i < N; i++) {
-                    if (readers.size() > 0) {
-                        readers.remove(readers.first());
-                        logger.debug("readers: {}, remove first reader", readers.size());
-                    } else {
-                        logger.debug("readers: {}, list is empty", readers.size());
-                    }
+                        try{
+                            SeReader seReader = readers.first();
+                            readers.remove(seReader);
+                            logger.debug("readers: {}, remove first reader", readers.size());
+                        }catch (NoSuchElementException e){
+                            //list is empty
+                            logger.debug("readers: {}, list is empty", readers.size());
+                        }
                     try {
                         Thread.sleep(10);
                     } catch (InterruptedException e) {

--- a/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/nativese/SlaveAPI.java
+++ b/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/nativese/SlaveAPI.java
@@ -14,6 +14,8 @@ package org.eclipse.keyple.plugin.remotese.nativese;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.eclipse.keyple.core.seproxy.ReaderPlugin;
 import org.eclipse.keyple.core.seproxy.ReaderPoolPlugin;
 import org.eclipse.keyple.core.seproxy.SeProxyService;
@@ -72,12 +74,22 @@ public class SlaveAPI implements INativeReaderService, DtoHandler, ObservableRea
      * @param masterNodeId : Master Node Id to connect to
      */
     public SlaveAPI(SeProxyService seProxyService, DtoNode dtoNode, String masterNodeId) {
-        this.seProxyService = seProxyService;
-        this.dtoNode = dtoNode;
-        this.rmTxEngine = new RemoteMethodTxEngine(dtoNode, DEFAULT_RPC_TIMEOUT);
-        this.masterNodeId = masterNodeId;
-        this.bindDtoEndpoint(dtoNode);
+        this(seProxyService, dtoNode, masterNodeId, DEFAULT_RPC_TIMEOUT);
     }
+
+    /**
+     * Constructor with custom timeout
+     *
+     * @param seProxyService : instance of the seProxyService
+     * @param dtoNode : Define which DTO sender will be called when a DTO needs to be sent.
+     * @param masterNodeId : Master Node Id to connect to
+     * @param timeout : timeout to be used before a request is abandonned
+     */
+    public SlaveAPI(SeProxyService seProxyService, DtoNode dtoNode, String masterNodeId,
+            long timeout) {
+        this(seProxyService, dtoNode, masterNodeId, timeout, Executors.newSingleThreadExecutor());
+    }
+
 
     /**
      * Constructor with custom timeout
@@ -86,12 +98,13 @@ public class SlaveAPI implements INativeReaderService, DtoHandler, ObservableRea
      * @param dtoNode : Define which DTO sender will be called when a DTO needs to be sent.
      * @param masterNodeId : Master Node Id to connect to
      * @param timeout : timeout to be used before a request is abandonned
+     * @param executorService : use an external executorService to execute async task
      */
     public SlaveAPI(SeProxyService seProxyService, DtoNode dtoNode, String masterNodeId,
-            long timeout) {
+            long timeout, ExecutorService executorService) {
         this.seProxyService = seProxyService;
         this.dtoNode = dtoNode;
-        this.rmTxEngine = new RemoteMethodTxEngine(dtoNode, timeout);
+        this.rmTxEngine = new RemoteMethodTxEngine(dtoNode, timeout, executorService);
         this.masterNodeId = masterNodeId;
         this.bindDtoEndpoint(dtoNode);
     }

--- a/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/nativese/SlaveAPI.java
+++ b/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/nativese/SlaveAPI.java
@@ -67,7 +67,7 @@ public class SlaveAPI implements INativeReaderService, DtoHandler, ObservableRea
 
 
     /**
-     * Constructor with a default timeout DEFAULT_RPC_TIMEOUT
+     * Constructor with a default timeout DEFAULT_RPC_TIMEOUT and single threaded executorService
      * 
      * @param seProxyService : instance of the seProxyService
      * @param dtoNode : Define which DTO sender will be called when a DTO needs to be sent.
@@ -78,7 +78,7 @@ public class SlaveAPI implements INativeReaderService, DtoHandler, ObservableRea
     }
 
     /**
-     * Constructor with custom timeout
+     * Constructor with custom timeout and single threaded executorService
      *
      * @param seProxyService : instance of the seProxyService
      * @param dtoNode : Define which DTO sender will be called when a DTO needs to be sent.
@@ -92,7 +92,7 @@ public class SlaveAPI implements INativeReaderService, DtoHandler, ObservableRea
 
 
     /**
-     * Constructor with custom timeout
+     * Constructor with custom timeout and custom executorService
      * 
      * @param seProxyService : instance of the seProxyService
      * @param dtoNode : Define which DTO sender will be called when a DTO needs to be sent.

--- a/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/pluginse/MasterAPI.java
+++ b/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/pluginse/MasterAPI.java
@@ -54,8 +54,7 @@ public class MasterAPI implements DtoHandler {
     protected final ExecutorService executorService;
 
     /**
-     * Build a new MasterAPI, Entry point for incoming DTO in Master Manages RemoteSePlugin
-     * lifecycle Manages Master Session Dispatch KeypleDTO
+     * Build a new MasterAPI with default rpc timeout and default executor service (cached pool)
      *
      * @param seProxyService : SeProxyService
      * @param dtoNode : outgoing node to send Dto to Slave
@@ -67,8 +66,7 @@ public class MasterAPI implements DtoHandler {
     }
 
     /**
-     * Build a new MasterAPI, Entry point for incoming DTO in Master Manages RemoteSePlugin
-     * lifecycle Manages Master Session Dispatch KeypleDTO
+     * Build a new MasterAPI with custom rpcTimeout and default executor service (cached pool)
      *
      * @param seProxyService : SeProxyService
      * @param dtoNode : outgoing node to send Dto to Slave
@@ -83,8 +81,7 @@ public class MasterAPI implements DtoHandler {
     }
 
     /**
-     * Build a new MasterAPI, Entry point for incoming DTO in Master Manages RemoteSePlugin
-     * lifecycle Manages Master Session Dispatch KeypleDTO
+     * Build a new MasterAPI with custom rpcTimeout and default executor service (cached pool)
      *
      * @param seProxyService : SeProxyService
      * @param dtoNode : outgoing node to send Dto to Slave
@@ -104,8 +101,7 @@ public class MasterAPI implements DtoHandler {
     }
 
     /**
-     * Build a new MasterAPI, Entry point for incoming DTO in Master Manages RemoteSePlugin
-     * lifecycle Manages Master Session Dispatch KeypleDTO
+     * Build a new MasterAPI with custom rpcTimeout and custom executor service
      *
      * @param seProxyService : SeProxyService
      * @param dtoNode : outgoing node to send Dto to Slave

--- a/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/pluginse/MasterAPI.java
+++ b/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/pluginse/MasterAPI.java
@@ -12,6 +12,8 @@
 package org.eclipse.keyple.plugin.remotese.pluginse;
 
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.eclipse.keyple.core.seproxy.SeProxyService;
 import org.eclipse.keyple.core.seproxy.SeReader;
 import org.eclipse.keyple.core.seproxy.exception.KeyplePluginInstantiationException;
@@ -49,6 +51,8 @@ public class MasterAPI implements DtoHandler {
 
     public static final long DEFAULT_RPC_TIMEOUT = 10000;
 
+    protected final ExecutorService executorService;
+
     /**
      * Build a new MasterAPI, Entry point for incoming DTO in Master Manages RemoteSePlugin
      * lifecycle Manages Master Session Dispatch KeypleDTO
@@ -68,13 +72,13 @@ public class MasterAPI implements DtoHandler {
      *
      * @param seProxyService : SeProxyService
      * @param dtoNode : outgoing node to send Dto to Slave
-     * @param rpc_timeout : timeout in milliseconds to wait for an answer from slave before throwing
+     * @param rpcTimeout : timeout in milliseconds to wait for an answer from slave before throwing
      *        an exception
      * @throws KeyplePluginInstantiationException if plugin does not instantiate
      */
-    public MasterAPI(SeProxyService seProxyService, DtoNode dtoNode, long rpc_timeout)
+    public MasterAPI(SeProxyService seProxyService, DtoNode dtoNode, long rpcTimeout)
             throws KeyplePluginInstantiationException {
-        this(seProxyService, dtoNode, rpc_timeout, PLUGIN_TYPE_DEFAULT,
+        this(seProxyService, dtoNode, rpcTimeout, PLUGIN_TYPE_DEFAULT,
                 RemoteSePluginImpl.DEFAULT_PLUGIN_NAME);
     }
 
@@ -91,14 +95,39 @@ public class MasterAPI implements DtoHandler {
      * @param pluginName : specify a name for remoteseplugin
      * @throws KeyplePluginInstantiationException if plugin does not instantiate
      *
-     * 
+     *
      */
     public MasterAPI(SeProxyService seProxyService, DtoNode dtoNode, long rpcTimeout,
             int pluginType, String pluginName) throws KeyplePluginInstantiationException {
+        this(seProxyService, dtoNode, rpcTimeout, pluginType, pluginName,
+                Executors.newCachedThreadPool());
+    }
+
+    /**
+     * Build a new MasterAPI, Entry point for incoming DTO in Master Manages RemoteSePlugin
+     * lifecycle Manages Master Session Dispatch KeypleDTO
+     *
+     * @param seProxyService : SeProxyService
+     * @param dtoNode : outgoing node to send Dto to Slave
+     * @param rpcTimeout : timeout in milliseconds to wait for an answer from slave before throwing
+     *        an exception
+     * @param pluginType : either a default plugin or readerPool plugin, use
+     *        {@link #PLUGIN_TYPE_DEFAULT} or @PLUGIN_TYPE_POOL
+     * @param pluginName : specify a name for remoteseplugin
+     * @param executorService : use an external executorService to execute async task
+     * @throws KeyplePluginInstantiationException if plugin does not instantiate
+     *
+     * 
+     */
+    public MasterAPI(SeProxyService seProxyService, DtoNode dtoNode, long rpcTimeout,
+            int pluginType, String pluginName, ExecutorService executorService)
+            throws KeyplePluginInstantiationException {
 
         logger.info("Init MasterAPI with parameters {} {} {} {} {}", seProxyService, dtoNode,
                 rpcTimeout, pluginType, pluginName);
 
+        // init executorService
+        this.executorService = executorService;
 
         this.dtoTransportNode = dtoNode;
         this.pluginType = pluginType;
@@ -122,8 +151,8 @@ public class MasterAPI implements DtoHandler {
                             "plugin name is already registered to the platform : " + pluginName);
                 }
 
-                seProxyService.registerPlugin(
-                        new RemoteSePluginFactory(sessionManager, dtoNode, rpcTimeout, pluginName));
+                seProxyService.registerPlugin(new RemoteSePluginFactory(sessionManager, dtoNode,
+                        rpcTimeout, pluginName, executorService));
 
                 this.plugin = (RemoteSePluginImpl) seProxyService.getPlugin(pluginName);
 
@@ -138,7 +167,7 @@ public class MasterAPI implements DtoHandler {
                 }
 
                 seProxyService.registerPlugin(new RemoteSePoolPluginFactory(sessionManager, dtoNode,
-                        rpcTimeout, pluginName));
+                        rpcTimeout, pluginName, executorService));
 
                 this.plugin = (RemoteSePoolPluginImpl) seProxyService.getPlugin(pluginName);
 

--- a/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/pluginse/RemoteSePluginFactory.java
+++ b/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/pluginse/RemoteSePluginFactory.java
@@ -11,6 +11,7 @@
  ********************************************************************************/
 package org.eclipse.keyple.plugin.remotese.pluginse;
 
+import java.util.concurrent.ExecutorService;
 import org.eclipse.keyple.core.seproxy.AbstractPluginFactory;
 import org.eclipse.keyple.core.seproxy.ReaderPlugin;
 import org.eclipse.keyple.plugin.remotese.transport.DtoSender;
@@ -24,13 +25,15 @@ class RemoteSePluginFactory extends AbstractPluginFactory {
     DtoSender dtoSender;
     long rpc_timeout;
     String pluginName;
+    ExecutorService executorService;
 
     public RemoteSePluginFactory(VirtualReaderSessionFactory sessionManager, DtoSender dtoSender,
-            long rpc_timeout, String pluginName) {
+            long rpc_timeout, String pluginName, ExecutorService executorService) {
         this.sessionManager = sessionManager;
         this.dtoSender = dtoSender;
         this.rpc_timeout = rpc_timeout;
         this.pluginName = pluginName;
+        this.executorService = executorService;
     }
 
     @Override
@@ -40,6 +43,7 @@ class RemoteSePluginFactory extends AbstractPluginFactory {
 
     @Override
     protected ReaderPlugin getPluginInstance() {
-        return new RemoteSePluginImpl(sessionManager, dtoSender, rpc_timeout, pluginName);
+        return new RemoteSePluginImpl(sessionManager, dtoSender, rpc_timeout, pluginName,
+                executorService);
     }
 }

--- a/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/pluginse/RemoteSePluginImpl.java
+++ b/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/pluginse/RemoteSePluginImpl.java
@@ -12,6 +12,7 @@
 package org.eclipse.keyple.plugin.remotese.pluginse;
 
 import java.util.*;
+import java.util.concurrent.ExecutorService;
 import org.eclipse.keyple.core.seproxy.SeReader;
 import org.eclipse.keyple.core.seproxy.event.PluginEvent;
 import org.eclipse.keyple.core.seproxy.event.ReaderEvent;
@@ -41,19 +42,21 @@ class RemoteSePluginImpl extends AbstractObservablePlugin implements RemoteSePlu
     private final VirtualReaderSessionFactory sessionManager;
     protected final DtoSender dtoSender;
     private final Map<String, String> parameters;
+    private ExecutorService executorService;
 
     /**
      * RemoteSePlugin is wrapped into MasterAPI and instantiated like a standard plugin
      * by @SeProxyService. Use MasterAPI
      */
     RemoteSePluginImpl(VirtualReaderSessionFactory sessionManager, DtoSender dtoSender,
-            long rpcTimeout, String pluginName) {
+            long rpcTimeout, String pluginName, ExecutorService executorService) {
         super(pluginName);
         this.sessionManager = sessionManager;
         logger.info("Init RemoteSePlugin");
         this.dtoSender = dtoSender;
         this.parameters = new HashMap<String, String>();
         this.rpcTimeout = rpcTimeout;
+        this.executorService = executorService;
     }
 
 
@@ -109,12 +112,12 @@ class RemoteSePluginImpl extends AbstractObservablePlugin implements RemoteSePlu
         VirtualReaderImpl virtualReader;
         if (Boolean.TRUE.equals(isObservable)) {
             virtualReader = new VirtualObservableReaderImpl(session, nativeReaderName,
-                    new RemoteMethodTxEngine(dtoSender, rpcTimeout), slaveNodeId, transmissionMode,
-                    options);
+                    new RemoteMethodTxEngine(dtoSender, rpcTimeout, executorService), slaveNodeId,
+                    transmissionMode, options);
         } else {
             virtualReader = new VirtualReaderImpl(session, nativeReaderName,
-                    new RemoteMethodTxEngine(dtoSender, rpcTimeout), slaveNodeId, transmissionMode,
-                    options);
+                    new RemoteMethodTxEngine(dtoSender, rpcTimeout, executorService), slaveNodeId,
+                    transmissionMode, options);
         }
         readers.add(virtualReader);
 

--- a/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/pluginse/RemoteSePoolPluginFactory.java
+++ b/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/pluginse/RemoteSePoolPluginFactory.java
@@ -11,6 +11,7 @@
  ********************************************************************************/
 package org.eclipse.keyple.plugin.remotese.pluginse;
 
+import java.util.concurrent.ExecutorService;
 import org.eclipse.keyple.core.seproxy.AbstractPluginFactory;
 import org.eclipse.keyple.core.seproxy.ReaderPlugin;
 import org.eclipse.keyple.plugin.remotese.transport.DtoSender;
@@ -24,13 +25,15 @@ class RemoteSePoolPluginFactory extends AbstractPluginFactory {
     DtoSender dtoSender;
     long rpc_timeout;
     String pluginName;
+    ExecutorService executorService;
 
     RemoteSePoolPluginFactory(VirtualReaderSessionFactory sessionManager, DtoSender dtoSender,
-            long rpc_timeout, String pluginName) {
+            long rpc_timeout, String pluginName, ExecutorService executorService) {
         this.sessionManager = sessionManager;
         this.dtoSender = dtoSender;
         this.rpc_timeout = rpc_timeout;
         this.pluginName = pluginName;
+        this.executorService = executorService;
     }
 
     @Override
@@ -40,6 +43,7 @@ class RemoteSePoolPluginFactory extends AbstractPluginFactory {
 
     @Override
     protected ReaderPlugin getPluginInstance() {
-        return new RemoteSePoolPluginImpl(sessionManager, dtoSender, rpc_timeout, pluginName);
+        return new RemoteSePoolPluginImpl(sessionManager, dtoSender, rpc_timeout, pluginName,
+                executorService);
     }
 }

--- a/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/pluginse/RemoteSePoolPluginImpl.java
+++ b/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/pluginse/RemoteSePoolPluginImpl.java
@@ -12,6 +12,7 @@
 package org.eclipse.keyple.plugin.remotese.pluginse;
 
 import java.util.SortedSet;
+import java.util.concurrent.ExecutorService;
 import org.eclipse.keyple.core.seproxy.SeReader;
 import org.eclipse.keyple.core.seproxy.exception.KeypleAllocationReaderException;
 import org.eclipse.keyple.plugin.remotese.exception.KeypleRemoteException;
@@ -38,11 +39,11 @@ class RemoteSePoolPluginImpl extends RemoteSePluginImpl implements RemoteSePoolP
      * Only {@link MasterAPI} can instantiate a RemoteSePlugin
      */
     RemoteSePoolPluginImpl(VirtualReaderSessionFactory sessionManager, DtoSender sender,
-            long rpcTimeout, String pluginName) {
-        super(sessionManager, sender, rpcTimeout, pluginName);
+            long rpcTimeout, String pluginName, ExecutorService executorService) {
+        super(sessionManager, sender, rpcTimeout, pluginName, executorService);
 
         // allocate a rmTxPoolEngine
-        rmTxEngine = new RemoteMethodTxPoolEngine(sender, rpcTimeout);
+        rmTxEngine = new RemoteMethodTxPoolEngine(sender, rpcTimeout, executorService);
     }
 
     public void bind(String slaveNodeId) {

--- a/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/pluginse/VirtualObservableReaderImpl.java
+++ b/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/pluginse/VirtualObservableReaderImpl.java
@@ -158,7 +158,7 @@ final class VirtualObservableReaderImpl extends VirtualReaderImpl
             final VirtualObservableReaderImpl thisReader = this;
             // launch event another thread to permit blocking method to be used in update
             // method (such as transmit)
-            executorService.execute(new Runnable() {
+            rmTxEngine.getExecutorService().execute(new Runnable() {
                 @Override
                 public void run() {
                     thisReader.notifyObservers(event);

--- a/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/pluginse/VirtualReaderImpl.java
+++ b/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/pluginse/VirtualReaderImpl.java
@@ -15,8 +15,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import org.eclipse.keyple.core.seproxy.ChannelControl;
 import org.eclipse.keyple.core.seproxy.MultiSeRequestProcessing;
 import org.eclipse.keyple.core.seproxy.exception.KeypleReaderException;
@@ -43,8 +41,6 @@ class VirtualReaderImpl extends AbstractReader implements VirtualReader {
     protected final RemoteMethodTxEngine rmTxEngine;
     protected final String slaveNodeId;
     protected final TransmissionMode transmissionMode;
-
-    protected final ExecutorService executorService = Executors.newSingleThreadExecutor();
 
     private static final Logger logger = LoggerFactory.getLogger(VirtualReaderImpl.class);
 

--- a/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/pluginse/VirtualReaderSession.java
+++ b/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/pluginse/VirtualReaderSession.java
@@ -14,6 +14,9 @@ package org.eclipse.keyple.plugin.remotese.pluginse;
 
 import java.util.Date;
 
+/**
+ * Stores meta information on the virtual reader such as slave, master node id and createdTime
+ */
 public interface VirtualReaderSession {
 
     /**

--- a/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/pluginse/VirtualReaderSession.java
+++ b/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/pluginse/VirtualReaderSession.java
@@ -12,6 +12,7 @@
 package org.eclipse.keyple.plugin.remotese.pluginse;
 
 
+import java.util.Date;
 
 public interface VirtualReaderSession {
 
@@ -25,5 +26,7 @@ public interface VirtualReaderSession {
     String getSlaveNodeId();
 
     String getMasterNodeId();
+
+    Date getCreatedTime();
 
 }

--- a/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/pluginse/VirtualReaderSessionImpl.java
+++ b/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/pluginse/VirtualReaderSessionImpl.java
@@ -13,6 +13,7 @@ package org.eclipse.keyple.plugin.remotese.pluginse;
 
 
 
+import java.util.Date;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,6 +27,7 @@ public class VirtualReaderSessionImpl implements VirtualReaderSession {
     private final String sessionId;
     private final String slaveNodeId;
     private final String masterNodeId;
+    private final Date createdDate;
 
     // constructor
     public VirtualReaderSessionImpl(String sessionId, String slaveNodeId, String masterNodeId) {
@@ -43,6 +45,7 @@ public class VirtualReaderSessionImpl implements VirtualReaderSession {
         this.sessionId = sessionId;
         this.slaveNodeId = slaveNodeId;
         this.masterNodeId = masterNodeId;
+        this.createdDate = new Date();
     }
 
 
@@ -56,11 +59,16 @@ public class VirtualReaderSessionImpl implements VirtualReaderSession {
         return slaveNodeId;
     }
 
-
     @Override
     public String getMasterNodeId() {
         return masterNodeId;
     }
+
+    @Override
+    public Date getCreatedTime() {
+        return createdDate;
+    }
+
 
     @Override
     public String toString() {

--- a/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/rm/AbstractRemoteMethodTx.java
+++ b/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/rm/AbstractRemoteMethodTx.java
@@ -116,8 +116,8 @@ public abstract class AbstractRemoteMethodTx<T> {
      */
     final public T execute(IRemoteMethodTxEngine rmTxEngine) throws KeypleRemoteException {
 
-        if (logger.isTraceEnabled()) {
-            logger.trace("execute {}", this.toString());
+        if (logger.isDebugEnabled()) {
+            logger.debug("execute {}", this.toString());
         }
         // register this method to receive response
         rmTxEngine.register(this);

--- a/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/rm/RemoteMethodTxEngine.java
+++ b/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/rm/RemoteMethodTxEngine.java
@@ -11,6 +11,7 @@
  ********************************************************************************/
 package org.eclipse.keyple.plugin.remotese.rm;
 
+import java.util.concurrent.ExecutorService;
 import org.eclipse.keyple.plugin.remotese.transport.*;
 import org.eclipse.keyple.plugin.remotese.transport.model.KeypleDto;
 import org.eclipse.keyple.plugin.remotese.transport.model.KeypleDtoHelper;
@@ -27,9 +28,11 @@ public class RemoteMethodTxEngine implements DtoHandler, IRemoteMethodTxEngine {
 
     private static final Logger logger = LoggerFactory.getLogger(RemoteMethodTxEngine.class);
 
-
     // waiting transaction, supports only one at the time
     private AbstractRemoteMethodTx remoteMethodTx;
+
+    // Executor to run async task required in RemoteMethodTx
+    final private ExecutorService executorService;
 
     // Dto Sender
     private final DtoSender sender;
@@ -37,17 +40,22 @@ public class RemoteMethodTxEngine implements DtoHandler, IRemoteMethodTxEngine {
     // timeout to wait for the answer, in milliseconds
     private final long timeout;
 
+
     /**
      *
      * @param sender : dtosender used to send the keypleDto
      * @param timeout : timeout to wait for the answer, in milliseconds
      */
-    public RemoteMethodTxEngine(DtoSender sender, long timeout) {
+    public RemoteMethodTxEngine(DtoSender sender, long timeout, ExecutorService executorService) {
         // this.queue = new LinkedList<RemoteMethodTx>();
         this.sender = sender;
         this.timeout = timeout;
+        this.executorService = executorService;
     }
 
+    public ExecutorService getExecutorService() {
+        return executorService;
+    }
 
     /**
      * Set Response to a RemoteMethod Invocation
@@ -111,6 +119,7 @@ public class RemoteMethodTxEngine implements DtoHandler, IRemoteMethodTxEngine {
         if (logger.isTraceEnabled()) {
             logger.trace("Register RemoteMethod to engine : {} ", rm.id);
         }
+        rm.setExecutorService(executorService);
         rm.setRegistered(true);
         remoteMethodTx = rm;
         rm.setDtoSender(sender);

--- a/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/rm/RemoteMethodTxPoolEngine.java
+++ b/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/rm/RemoteMethodTxPoolEngine.java
@@ -13,6 +13,7 @@ package org.eclipse.keyple.plugin.remotese.rm;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import org.eclipse.keyple.plugin.remotese.transport.DtoHandler;
 import org.eclipse.keyple.plugin.remotese.transport.DtoSender;
@@ -49,7 +50,7 @@ public class RemoteMethodTxPoolEngine implements DtoHandler, IRemoteMethodTxEngi
      */
     public RemoteMethodTxPoolEngine(DtoSender sender, long timeout,
             ExecutorService executorService) {
-        this.queue = new HashMap<String, AbstractRemoteMethodTx>();
+        this.queue = new ConcurrentHashMap<String, AbstractRemoteMethodTx>();
         this.sender = sender;
         this.timeout = timeout;
         this.executorService = executorService;

--- a/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/rm/RemoteMethodTxPoolEngine.java
+++ b/java/component/keyple-plugin/remotese/src/main/java/org/eclipse/keyple/plugin/remotese/rm/RemoteMethodTxPoolEngine.java
@@ -13,6 +13,7 @@ package org.eclipse.keyple.plugin.remotese.rm;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 import org.eclipse.keyple.plugin.remotese.transport.DtoHandler;
 import org.eclipse.keyple.plugin.remotese.transport.DtoSender;
 import org.eclipse.keyple.plugin.remotese.transport.model.KeypleDto;
@@ -30,10 +31,11 @@ public class RemoteMethodTxPoolEngine implements DtoHandler, IRemoteMethodTxEngi
 
     private static final Logger logger = LoggerFactory.getLogger(RemoteMethodTxPoolEngine.class);
 
-
     // rm id, rm
     private Map<String, AbstractRemoteMethodTx> queue;
 
+    // Executor to run async task required in RemoteMethodTx
+    final private ExecutorService executorService;
     // Dto Sender
     private final DtoSender sender;
 
@@ -45,10 +47,12 @@ public class RemoteMethodTxPoolEngine implements DtoHandler, IRemoteMethodTxEngi
      * @param sender : dtosender used to send the keypleDto
      * @param timeout : timeout to wait for the answer, in milliseconds
      */
-    public RemoteMethodTxPoolEngine(DtoSender sender, long timeout) {
+    public RemoteMethodTxPoolEngine(DtoSender sender, long timeout,
+            ExecutorService executorService) {
         this.queue = new HashMap<String, AbstractRemoteMethodTx>();
         this.sender = sender;
         this.timeout = timeout;
+        this.executorService = executorService;
     }
 
 
@@ -91,6 +95,7 @@ public class RemoteMethodTxPoolEngine implements DtoHandler, IRemoteMethodTxEngi
     public void register(final AbstractRemoteMethodTx rm) {
         logger.debug("Register rm to engine : {}", rm);
         rm.setRegistered(true);
+        rm.setExecutorService(executorService);
         queue.put(rm.id, rm);
         rm.setDtoSender(sender);
         rm.setTimeout(timeout);

--- a/java/component/keyple-plugin/remotese/src/test/java/org/eclipse/keyple/plugin/remotese/integration/VirtualReaderParameterTest.java
+++ b/java/component/keyple-plugin/remotese/src/test/java/org/eclipse/keyple/plugin/remotese/integration/VirtualReaderParameterTest.java
@@ -65,4 +65,19 @@ public class VirtualReaderParameterTest extends VirtualReaderBaseTest {
                 nativeReader.getTransmissionMode());
     }
 
+    @Test
+    public void testGetSession() throws Exception {
+        // configure and connect a Stub Native reader
+        nativeReader = this.connectStubReader(NATIVE_READER_NAME, CLIENT_NODE_ID,
+                TransmissionMode.CONTACTLESS);
+
+        // test virtual reader
+        virtualReader = getVirtualReader();
+
+        Assert.assertNotNull(virtualReader.getSession().getCreatedTime());
+        Assert.assertNotNull(virtualReader.getSession().getSessionId());
+        Assert.assertNotNull(virtualReader.getSession().getMasterNodeId(), SERVER_NODE_ID);
+        Assert.assertNotNull(virtualReader.getSession().getSlaveNodeId(), CLIENT_NODE_ID);
+    }
+
 }

--- a/java/component/keyple-plugin/remotese/src/test/java/org/eclipse/keyple/plugin/remotese/pluginse/RemoteSePluginImplTest.java
+++ b/java/component/keyple-plugin/remotese/src/test/java/org/eclipse/keyple/plugin/remotese/pluginse/RemoteSePluginImplTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.doReturn;
 import java.util.HashMap;
 import java.util.SortedSet;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.eclipse.keyple.core.seproxy.SeReader;
 import org.eclipse.keyple.core.seproxy.exception.KeypleReaderException;
@@ -65,7 +66,7 @@ public class RemoteSePluginImplTest extends CoreBaseTest {
         doReturn("masterNode1").when(dtoSender).getNodeId();
 
         RemoteSePluginImpl plugin = new RemoteSePluginImpl(new VirtualReaderSessionFactory(),
-                dtoSender, 10000, "pluginName");
+                dtoSender, 10000, "pluginName", Executors.newCachedThreadPool());
 
         SortedSet<SeReader> readers = plugin.getReaders();
 
@@ -82,7 +83,7 @@ public class RemoteSePluginImplTest extends CoreBaseTest {
         removeReaderThread(readers, 10, lock);
 
         // wait for all thread to finish with timeout
-        lock.await(3, TimeUnit.SECONDS);
+        lock.await(10, TimeUnit.SECONDS);
 
         // if all thread finished correctly, lock count should be 0
         Assert.assertEquals(0, lock.getCount());

--- a/java/example/calypso/remotese/src/main/java/org/eclipse/keyple/example/remote/application/Demo_Slave.java
+++ b/java/example/calypso/remotese/src/main/java/org/eclipse/keyple/example/remote/application/Demo_Slave.java
@@ -94,8 +94,7 @@ public class Demo_Slave {
                 }.start();
 
                 // if slave is server, must specify which master to connect to
-                slaveAPI =
-                        new SlaveAPI(SeProxyService.getInstance(), node, masterNodeId, RPC_TIMEOUT);
+                slaveAPI = new SlaveAPI(SeProxyService.getInstance(), node, masterNodeId);
 
                 initPoReader();
 


### PR DESCRIPTION
- use an executorService instead of creating new Thread() in RPC engine
- on master side :  by default, use a unlimited thread pool with a 1 minute timeout
- on slave side :  by default, use a single thread pool
- make it configurable externally
