### PR TITLE
feat: KEYP-12/250-251 refactor selectors

### DIFF
--- a/android/keyple-plugin/android-omapi/src/main/kotlin/org/eclipse/keyple/plugin/android/omapi/se/AndroidOmapiReader.kt
+++ b/android/keyple-plugin/android-omapi/src/main/kotlin/org/eclipse/keyple/plugin/android/omapi/se/AndroidOmapiReader.kt
@@ -79,10 +79,10 @@ internal class AndroidOmapiReader(private val nativeReader: Reader, pluginName: 
             }
         } else {
             Timber.i("[%s] openLogicalChannel => Select Application with AID = %s",
-                    this.name, ByteArrayUtil.toHex(aidSelector.aidToSelect.value))
+                    this.name, ByteArrayUtil.toHex(aidSelector.aidToSelect))
             try {
                 openChannel =
-                        session?.openLogicalChannel(aidSelector.aidToSelect.value,
+                        session?.openLogicalChannel(aidSelector.aidToSelect,
                         aidSelector.fileOccurrence.isoBitMask or aidSelector.fileControlInformation.isoBitMask)
             } catch (e: IOException) {
                 Timber.e(e, "IOException")
@@ -90,10 +90,10 @@ internal class AndroidOmapiReader(private val nativeReader: Reader, pluginName: 
             } catch (e: NoSuchElementException) {
                 Timber.e(e, "NoSuchElementException")
                 throw java.lang.IllegalArgumentException(
-                        "NoSuchElementException: " + ByteArrayUtil.toHex(aidSelector.getAidToSelect().value), e)
+                        "NoSuchElementException: " + ByteArrayUtil.toHex(aidSelector.aidToSelect), e)
             } catch (e: SecurityException) {
                 Timber.e(e, "SecurityException")
-                throw KeypleReaderIOException("SecurityException while opening logical channel, aid :" + ByteArrayUtil.toHex(aidSelector.getAidToSelect().value), e.cause)
+                throw KeypleReaderIOException("SecurityException while opening logical channel, aid :" + ByteArrayUtil.toHex(aidSelector.aidToSelect), e.cause)
             }
 
             if (openChannel == null) {

--- a/android/keyple-plugin/android-omapi/src/main/kotlin/org/eclipse/keyple/plugin/android/omapi/simalliance/AndroidOmapiReader.kt
+++ b/android/keyple-plugin/android-omapi/src/main/kotlin/org/eclipse/keyple/plugin/android/omapi/simalliance/AndroidOmapiReader.kt
@@ -82,7 +82,7 @@ internal class AndroidOmapiReader(private val nativeReader: Reader, pluginName: 
             }
         } else {
             Timber.i("[%s] openLogicalChannel => Select Application with AID = %s",
-                    this.name, ByteArrayUtil.toHex(aidSelector.aidToSelect.value))
+                    this.name, ByteArrayUtil.toHex(aidSelector.aidToSelect))
             try {
                 // openLogicalChannel of SimAlliance OMAPI is only available for version 3.0+ of the library.
                 // By default the library always passes p2=00h
@@ -90,10 +90,10 @@ internal class AndroidOmapiReader(private val nativeReader: Reader, pluginName: 
                 val p2 = aidSelector.fileOccurrence.isoBitMask or aidSelector.fileControlInformation.isoBitMask
                 openChannel =
                         if (0 == p2.toInt()) {
-                            session?.openLogicalChannel(aidSelector.aidToSelect.value)
+                            session?.openLogicalChannel(aidSelector.aidToSelect)
                         } else {
                             if (omapiVersion >= P2_SUPPORTED_MIN_VERSION) {
-                                session?.openLogicalChannel(aidSelector.aidToSelect.value, p2)
+                                session?.openLogicalChannel(aidSelector.aidToSelect, p2)
                             } else {
                                 throw KeypleReaderIOException("P2 != 00h while opening logical channel is only supported by OMAPI version >= 3.0. Current is $omapiVersion")
                             }
@@ -104,10 +104,10 @@ internal class AndroidOmapiReader(private val nativeReader: Reader, pluginName: 
             } catch (e: NoSuchElementException) {
                 Timber.e(e, "NoSuchElementException")
                 throw java.lang.IllegalArgumentException(
-                        "NoSuchElementException: " + ByteArrayUtil.toHex(aidSelector.aidToSelect.value), e)
+                        "NoSuchElementException: " + ByteArrayUtil.toHex(aidSelector.aidToSelect), e)
             } catch (e: SecurityException) {
                 Timber.e(e, "SecurityException")
-                throw KeypleReaderIOException("SecurityException while opening logical channel, aid :" + ByteArrayUtil.toHex(aidSelector.aidToSelect.value), e.cause)
+                throw KeypleReaderIOException("SecurityException while opening logical channel, aid :" + ByteArrayUtil.toHex(aidSelector.aidToSelect), e.cause)
             }
 
             if (openChannel == null) {

--- a/android/keyple-plugin/android-omapi/src/test/kotlin/org/eclipse/keyple/plugin/android/omapi/AbstractAndroidOmapiReaderTest.kt
+++ b/android/keyple-plugin/android-omapi/src/test/kotlin/org/eclipse/keyple/plugin/android/omapi/AbstractAndroidOmapiReaderTest.kt
@@ -189,8 +189,10 @@ internal abstract class AbstractAndroidOmapiReaderTest<T, V : AbstractAndroidOma
         val poAid = "A000000291A000000191"
 
         // wrong protocol
-        val seRequest = SeRequest(SeSelector(SeCommonProtocols.PROTOCOL_MIFARE_UL, null,
-                SeSelector.AidSelector(SeSelector.AidSelector.IsoAid(poAid))), ArrayList())
+        val seRequest = SeRequest(SeSelector.builder()
+                .seProtocol(SeCommonProtocols.PROTOCOL_MIFARE_UL)
+                .aidSelector(SeSelector.AidSelector.builder()
+                        .aidToSelect(poAid).build()).build(), ArrayList())
 
         // test
         val seRequests = ArrayList<SeRequest>()
@@ -249,8 +251,10 @@ internal abstract class AbstractAndroidOmapiReaderTest<T, V : AbstractAndroidOma
 
         val poApduRequestList = listOf(ApduRequest(ByteArrayUtil.fromHex("0000"), true))
 
-        val seRequest = SeRequest(SeSelector(SeCommonProtocols.PROTOCOL_ISO7816_3, null,
-                SeSelector.AidSelector(SeSelector.AidSelector.IsoAid(PO_AID))), poApduRequestList)
+        val seRequest = SeRequest(SeSelector.builder()
+                .seProtocol(SeCommonProtocols.PROTOCOL_ISO7816_3)
+                .aidSelector(SeSelector.AidSelector.builder()
+                        .aidToSelect(PO_AID).build()).build(), poApduRequestList)
 
         val seRequestSet = ArrayList<SeRequest>()
         seRequestSet.add(seRequest)
@@ -261,8 +265,8 @@ internal abstract class AbstractAndroidOmapiReaderTest<T, V : AbstractAndroidOma
 
         val poApduRequestList = listOf(ApduRequest(ByteArrayUtil.fromHex("0000"), true))
 
-        val seRequest = SeRequest(SeSelector(SeCommonProtocols.PROTOCOL_ISO7816_3, null,
-                SeSelector.AidSelector(null)), poApduRequestList)
+        val seRequest = SeRequest(SeSelector.builder()
+                .seProtocol(SeCommonProtocols.PROTOCOL_ISO7816_3).build(), poApduRequestList)
 
         val seRequestSet = ArrayList<SeRequest>()
         seRequestSet.add(seRequest)

--- a/android/keyple-plugin/android-omapi/src/test/kotlin/org/eclipse/keyple/plugin/android/omapi/simalliance/AndroidOmapiReaderTest.kt
+++ b/android/keyple-plugin/android-omapi/src/test/kotlin/org/eclipse/keyple/plugin/android/omapi/simalliance/AndroidOmapiReaderTest.kt
@@ -50,10 +50,12 @@ internal class AndroidOmapiReaderTest : AbstractAndroidOmapiReaderTest<Reader, A
 
         val poApduRequestList = listOf(ApduRequest(ByteArrayUtil.fromHex("0000"), true))
 
-        val seRequest = SeRequest(SeSelector(SeCommonProtocols.PROTOCOL_ISO7816_3, null,
-                SeSelector.AidSelector(SeSelector.AidSelector.IsoAid(PO_AID),
-                        SeSelector.AidSelector.FileOccurrence.NEXT,
-                        SeSelector.AidSelector.FileControlInformation.FCI)),
+        val seRequest = SeRequest(SeSelector.builder()
+                .seProtocol(SeCommonProtocols.PROTOCOL_ISO7816_3)
+                .aidSelector(SeSelector.AidSelector.builder().aidToSelect(PO_AID)
+                        .fileOccurrence(SeSelector.AidSelector.FileOccurrence.NEXT)
+                        .fileControlInformation(SeSelector.AidSelector.FileControlInformation.FCI).build())
+                .build(),
                 poApduRequestList)
 
         reader.transmitSeRequest(seRequest, ChannelControl.KEEP_OPEN)
@@ -66,10 +68,12 @@ internal class AndroidOmapiReaderTest : AbstractAndroidOmapiReaderTest<Reader, A
 
         val poApduRequestList = listOf(ApduRequest(ByteArrayUtil.fromHex("0000"), true))
 
-        val seRequest = SeRequest(SeSelector(SeCommonProtocols.PROTOCOL_ISO7816_3, null,
-                SeSelector.AidSelector(SeSelector.AidSelector.IsoAid(PO_AID),
-                        SeSelector.AidSelector.FileOccurrence.NEXT,
-                        SeSelector.AidSelector.FileControlInformation.FCI)),
+        val seRequest = SeRequest(SeSelector.builder()
+                .seProtocol(SeCommonProtocols.PROTOCOL_ISO7816_3)
+                .aidSelector(SeSelector.AidSelector.builder().aidToSelect(PO_AID)
+                        .fileOccurrence(SeSelector.AidSelector.FileOccurrence.NEXT)
+                        .fileControlInformation(SeSelector.AidSelector.FileControlInformation.FCI).build())
+                .build(),
                 poApduRequestList)
 
         val seRequests = ArrayList<SeRequest>()

--- a/java/component/keyple-calypso/src/main/java/org/eclipse/keyple/calypso/transaction/CalypsoSam.java
+++ b/java/component/keyple-calypso/src/main/java/org/eclipse/keyple/calypso/transaction/CalypsoSam.java
@@ -25,14 +25,14 @@ import org.slf4j.LoggerFactory;
 public final class CalypsoSam extends AbstractMatchingSe {
     private static final Logger logger = LoggerFactory.getLogger(CalypsoSam.class);
 
-    private SamRevision samRevision;
-    private byte[] serialNumber = new byte[4];
-    private byte platform;
-    private byte applicationType;
-    private byte applicationSubType;
-    private byte softwareIssuer;
-    private byte softwareVersion;
-    private byte softwareRevision;
+    private final SamRevision samRevision;
+    private final byte[] serialNumber = new byte[4];
+    private final byte platform;
+    private final byte applicationType;
+    private final byte applicationSubType;
+    private final byte softwareIssuer;
+    private final byte softwareVersion;
+    private final byte softwareRevision;
 
     /**
      * Constructor.

--- a/java/component/keyple-calypso/src/main/java/org/eclipse/keyple/calypso/transaction/PoSelector.java
+++ b/java/component/keyple-calypso/src/main/java/org/eclipse/keyple/calypso/transaction/PoSelector.java
@@ -12,6 +12,7 @@
 package org.eclipse.keyple.calypso.transaction;
 
 import org.eclipse.keyple.core.seproxy.SeSelector;
+import org.eclipse.keyple.core.seproxy.protocol.SeProtocol;
 
 /**
  * The {@link PoSelector} class extends {@link SeSelector} to handle specific PO features such as
@@ -30,7 +31,7 @@ public final class PoSelector extends SeSelector {
         REJECT, ACCEPT
     }
 
-    public PoSelector(PoSelectorBuilder<?> builder) {
+    public PoSelector(PoSelectorBuilder builder) {
         super(builder);
         if (builder.invalidatedPo == InvalidatedPo.ACCEPT) {
             this.getAidSelector().addSuccessfulStatusCode(SW_PO_INVALIDATED);
@@ -49,17 +50,31 @@ public final class PoSelector extends SeSelector {
      * 
      * @since 0.9
      */
-    protected abstract static class PoSelectorBuilder<T extends PoSelectorBuilder<T>>
-            extends SeSelector.SeSelectorBuilder<T> {
+    public static class PoSelectorBuilder extends SeSelector.SeSelectorBuilder {
         private InvalidatedPo invalidatedPo;
 
-        protected PoSelectorBuilder() {
+        private PoSelectorBuilder() {
             super();
         }
 
-        public T invalidatedPo(InvalidatedPo invalidatedPo) {
+        public PoSelectorBuilder invalidatedPo(InvalidatedPo invalidatedPo) {
             this.invalidatedPo = invalidatedPo;
-            return self();
+            return this;
+        }
+
+        @Override
+        public PoSelectorBuilder seProtocol(SeProtocol seProtocol) {
+            return (PoSelectorBuilder) super.seProtocol(seProtocol);
+        }
+
+        @Override
+        public PoSelectorBuilder atrFilter(AtrFilter atrFilter) {
+            return (PoSelectorBuilder) super.atrFilter(atrFilter);
+        }
+
+        @Override
+        public PoSelectorBuilder aidSelector(AidSelector aidSelector) {
+            return (PoSelectorBuilder) super.aidSelector(aidSelector);
         }
 
         @Override
@@ -68,13 +83,8 @@ public final class PoSelector extends SeSelector {
         }
     }
 
-    /**
-     * Gets a new builder.
-     */
-    public static class Builder extends PoSelectorBuilder<PoSelector.Builder> {
-        @Override
-        protected Builder self() {
-            return this;
-        }
+
+    public static PoSelectorBuilder builder() {
+        return new PoSelectorBuilder();
     }
 }

--- a/java/component/keyple-calypso/src/main/java/org/eclipse/keyple/calypso/transaction/PoSelector.java
+++ b/java/component/keyple-calypso/src/main/java/org/eclipse/keyple/calypso/transaction/PoSelector.java
@@ -12,7 +12,6 @@
 package org.eclipse.keyple.calypso.transaction;
 
 import org.eclipse.keyple.core.seproxy.SeSelector;
-import org.eclipse.keyple.core.seproxy.protocol.SeProtocol;
 
 /**
  * The {@link PoSelector} class extends {@link SeSelector} to handle specific PO features such as
@@ -31,19 +30,51 @@ public final class PoSelector extends SeSelector {
         REJECT, ACCEPT
     }
 
+    public PoSelector(PoSelectorBuilder<?> builder) {
+        super(builder);
+        if (builder.invalidatedPo == InvalidatedPo.ACCEPT) {
+            this.getAidSelector().addSuccessfulStatusCode(SW_PO_INVALIDATED);
+        }
+    }
+
     /**
-     * Create a PoSelector to perform the PO selection. See {@link SeSelector}
-     *
-     * @param seProtocol the SE communication protocol
-     * @param atrFilter the ATR filter
-     * @param aidSelector the AID selection data
-     * @param authorization enum to allow invalidated POs to be accepted
+     * Create a PoSelector to perform the PO selection. See {@link SeSelector}<br>
+     * All fields are optional
+     * <ul>
+     * <li>aid the AID selection data</li>
+     * <li>seProtocol the SE communication protocol</li>
+     * <li>atrFilter the ATR filter</li>
+     * <li>authorization enum to allow invalidated POs to be accepted</li>
+     * </ul>
+     * 
+     * @since 0.9
      */
-    public PoSelector(SeProtocol seProtocol, AtrFilter atrFilter, AidSelector aidSelector,
-            InvalidatedPo authorization) {
-        super(seProtocol, atrFilter, aidSelector);
-        if (authorization == InvalidatedPo.ACCEPT) {
-            aidSelector.addSuccessfulStatusCode(SW_PO_INVALIDATED);
+    protected abstract static class PoSelectorBuilder<T extends PoSelectorBuilder<T>>
+            extends SeSelector.SeSelectorBuilder<T> {
+        private InvalidatedPo invalidatedPo;
+
+        protected PoSelectorBuilder() {
+            super();
+        }
+
+        public T invalidatedPo(InvalidatedPo invalidatedPo) {
+            this.invalidatedPo = invalidatedPo;
+            return self();
+        }
+
+        @Override
+        public PoSelector build() {
+            return new PoSelector(this);
+        }
+    }
+
+    /**
+     * Gets a new builder.
+     */
+    public static class Builder extends PoSelectorBuilder<PoSelector.Builder> {
+        @Override
+        protected Builder self() {
+            return this;
         }
     }
 }

--- a/java/component/keyple-calypso/src/main/java/org/eclipse/keyple/calypso/transaction/PoSelector.java
+++ b/java/component/keyple-calypso/src/main/java/org/eclipse/keyple/calypso/transaction/PoSelector.java
@@ -41,7 +41,7 @@ public final class PoSelector extends SeSelector {
 
     /**
      * Builder of PoSelector
-     * 
+     *
      * @since 0.9
      */
     public static class PoSelectorBuilder extends SeSelector.SeSelectorBuilder {
@@ -53,7 +53,7 @@ public final class PoSelector extends SeSelector {
 
         /**
          * Sets the desired behaviour in case of invalidated POs
-         * 
+         *
          * @param invalidatedPo the {@link InvalidatedPo} wanted behaviour
          * @return the builder instance
          */

--- a/java/component/keyple-calypso/src/main/java/org/eclipse/keyple/calypso/transaction/PoSelector.java
+++ b/java/component/keyple-calypso/src/main/java/org/eclipse/keyple/calypso/transaction/PoSelector.java
@@ -31,7 +31,8 @@ public final class PoSelector extends SeSelector {
         REJECT, ACCEPT
     }
 
-    public PoSelector(PoSelectorBuilder builder) {
+    /** Private constructor */
+    private PoSelector(PoSelectorBuilder builder) {
         super(builder);
         if (builder.invalidatedPo == InvalidatedPo.ACCEPT) {
             this.getAidSelector().addSuccessfulStatusCode(SW_PO_INVALIDATED);
@@ -39,14 +40,7 @@ public final class PoSelector extends SeSelector {
     }
 
     /**
-     * Create a PoSelector to perform the PO selection. See {@link SeSelector}<br>
-     * All fields are optional
-     * <ul>
-     * <li>aid the AID selection data</li>
-     * <li>seProtocol the SE communication protocol</li>
-     * <li>atrFilter the ATR filter</li>
-     * <li>authorization enum to allow invalidated POs to be accepted</li>
-     * </ul>
+     * Builder of PoSelector
      * 
      * @since 0.9
      */
@@ -57,33 +51,57 @@ public final class PoSelector extends SeSelector {
             super();
         }
 
+        /**
+         * Sets the desired behaviour in case of invalidated POs
+         * 
+         * @param invalidatedPo the {@link InvalidatedPo} wanted behaviour
+         * @return the builder instance
+         */
         public PoSelectorBuilder invalidatedPo(InvalidatedPo invalidatedPo) {
             this.invalidatedPo = invalidatedPo;
             return this;
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public PoSelectorBuilder seProtocol(SeProtocol seProtocol) {
             return (PoSelectorBuilder) super.seProtocol(seProtocol);
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public PoSelectorBuilder atrFilter(AtrFilter atrFilter) {
             return (PoSelectorBuilder) super.atrFilter(atrFilter);
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public PoSelectorBuilder aidSelector(AidSelector aidSelector) {
             return (PoSelectorBuilder) super.aidSelector(aidSelector);
         }
 
+        /**
+         * Build a new {@code PoSelector}.
+         *
+         * @return a new instance
+         */
         @Override
         public PoSelector build() {
             return new PoSelector(this);
         }
     }
 
-
+    /**
+     * Gets a new builder.
+     *
+     * @return a new builder instance
+     */
     public static PoSelectorBuilder builder() {
         return new PoSelectorBuilder();
     }

--- a/java/component/keyple-calypso/src/main/java/org/eclipse/keyple/calypso/transaction/SamIdentifier.java
+++ b/java/component/keyple-calypso/src/main/java/org/eclipse/keyple/calypso/transaction/SamIdentifier.java
@@ -37,35 +37,53 @@ public class SamIdentifier {
     }
 
     /**
-     * Builder for a SamIdentifier
-     *
-     * Three optional paramters
-     * <ul>
-     * <li>samRevision the SAM revision</li>
-     * <li>serialNumber the SAM serial number as an hex string or a regular expression</li>
-     * <li>groupReference the group reference string</li>
-     * </ul>
+     * Builder for a {@link SamIdentifier}
+     * 
+     * @since 0.9
      */
     public static class SamIdentifierBuilder {
         private SamRevision samRevision;
         private String serialNumber = ""; // default: any S/N matches
         private String groupReference = "";
 
+        /**
+         * Sets the targeted SAM revision
+         * 
+         * @param samRevision the {@link SamRevision} of the targeted SAM
+         * @return the builder instance
+         */
         public SamIdentifierBuilder samRevision(SamRevision samRevision) {
             this.samRevision = samRevision;
             return this;
         }
 
+        /**
+         * Sets the targeted SAM serial number
+         * 
+         * @param serialNumber the serial number of the targeted SAM as regex
+         * @return the builder instance
+         */
         public SamIdentifierBuilder serialNumber(String serialNumber) {
             this.serialNumber = serialNumber;
             return this;
         }
 
+        /**
+         * Sets the targeted SAM group reference
+         * 
+         * @param groupReference the group reference of the targeted SAM as a string
+         * @return the builder instance
+         */
         public SamIdentifierBuilder groupReference(String groupReference) {
             this.groupReference = groupReference;
             return this;
         }
 
+        /**
+         * Build a new {@code SamIdentifier}.
+         *
+         * @return a new instance
+         */
         public SamIdentifier build() {
             return new SamIdentifier(this);
         }

--- a/java/component/keyple-calypso/src/main/java/org/eclipse/keyple/calypso/transaction/SamIdentifier.java
+++ b/java/component/keyple-calypso/src/main/java/org/eclipse/keyple/calypso/transaction/SamIdentifier.java
@@ -29,17 +29,55 @@ public class SamIdentifier {
     String serialNumber;
     String groupReference;
 
+    /** Private constructor */
+    private SamIdentifier(SamIdentifierBuilder builder) {
+        this.samRevision = builder.samRevision;
+        this.serialNumber = builder.serialNumber;
+        this.groupReference = builder.groupReference;
+    }
+
     /**
-     * Constructor for a SamIdentifier
-     * 
-     * @param samRevision the SAM revision
-     * @param serialNumber the SAM serial number as an hex string or a regular expression
-     * @param groupReference the group reference string
+     * Builder for a SamIdentifier
+     *
+     * Three optional paramters
+     * <ul>
+     * <li>samRevision the SAM revision</li>
+     * <li>serialNumber the SAM serial number as an hex string or a regular expression</li>
+     * <li>groupReference the group reference string</li>
+     * </ul>
      */
-    public SamIdentifier(SamRevision samRevision, String serialNumber, String groupReference) {
-        this.samRevision = samRevision;
-        this.serialNumber = serialNumber;
-        this.groupReference = groupReference;
+    public static class SamIdentifierBuilder {
+        private SamRevision samRevision;
+        private String serialNumber = "";
+        private String groupReference = "";
+
+        public SamIdentifierBuilder samRevision(SamRevision samRevision) {
+            this.samRevision = samRevision;
+            return this;
+        }
+
+        public SamIdentifierBuilder serialNumber(String serialNumber) {
+            this.serialNumber = serialNumber;
+            return this;
+        }
+
+        public SamIdentifierBuilder groupReference(String groupReference) {
+            this.groupReference = groupReference;
+            return this;
+        }
+
+        public SamIdentifier build() {
+            return new SamIdentifier(this);
+        }
+    }
+
+    /**
+     * Gets a new builder.
+     */
+    public static class Builder extends SamIdentifierBuilder {
+        protected SamIdentifierBuilder self() {
+            return this;
+        }
     }
 
     /**

--- a/java/component/keyple-calypso/src/main/java/org/eclipse/keyple/calypso/transaction/SamIdentifier.java
+++ b/java/component/keyple-calypso/src/main/java/org/eclipse/keyple/calypso/transaction/SamIdentifier.java
@@ -48,7 +48,7 @@ public class SamIdentifier {
      */
     public static class SamIdentifierBuilder {
         private SamRevision samRevision;
-        private String serialNumber = "";
+        private String serialNumber = ""; // default: any S/N matches
         private String groupReference = "";
 
         public SamIdentifierBuilder samRevision(SamRevision samRevision) {
@@ -73,11 +73,11 @@ public class SamIdentifier {
 
     /**
      * Gets a new builder.
+     *
+     * @return a new builder instance
      */
-    public static class Builder extends SamIdentifierBuilder {
-        protected SamIdentifierBuilder self() {
-            return this;
-        }
+    public static SamIdentifierBuilder builder() {
+        return new SamIdentifierBuilder();
     }
 
     /**

--- a/java/component/keyple-calypso/src/main/java/org/eclipse/keyple/calypso/transaction/SamResourceManager.java
+++ b/java/component/keyple-calypso/src/main/java/org/eclipse/keyple/calypso/transaction/SamResourceManager.java
@@ -86,7 +86,7 @@ public abstract class SamResourceManager {
         /* Prepare selector */
         samSelection.prepareSelection(
 
-                new SamSelectionRequest(new SamSelector.Builder()
+                new SamSelectionRequest(SamSelector.builder()
                         .samIdentifier(
                                 new SamIdentifier.SamIdentifierBuilder().samRevision(AUTO).build())
                         .build()));

--- a/java/component/keyple-calypso/src/main/java/org/eclipse/keyple/calypso/transaction/SamResourceManager.java
+++ b/java/component/keyple-calypso/src/main/java/org/eclipse/keyple/calypso/transaction/SamResourceManager.java
@@ -22,6 +22,7 @@ import org.eclipse.keyple.core.seproxy.exception.KeypleReaderException;
 
 /**
  * Management of SAM resources:
+ *
  * <p>
  * Provides methods fot the allocation/deallocation of SAM resources
  */
@@ -34,13 +35,16 @@ public abstract class SamResourceManager {
 
     /**
      * Allocate a SAM resource from the specified SAM group.
+     *
      * <p>
      * In the case where the allocation mode is BLOCKING, this method will wait until a SAM resource
      * becomes free and then return the reference to the allocated resource. However, the BLOCKING
      * mode will wait a maximum time defined in milliseconds by MAX_BLOCKING_TIME.
+     *
      * <p>
      * In the case where the allocation mode is NON_BLOCKING and no SAM resource is available, this
      * method will return an exception.
+     *
      * <p>
      * If the samGroup argument is null, the first available SAM resource will be selected and
      * returned regardless of its group.
@@ -65,6 +69,7 @@ public abstract class SamResourceManager {
 
     /**
      * Create a SAM resource from the provided SAM reader.
+     *
      * <p>
      * Proceed with the SAM selection and combine the SAM reader and the Calypso SAM resulting from
      * the selection.
@@ -80,7 +85,11 @@ public abstract class SamResourceManager {
 
         /* Prepare selector */
         samSelection.prepareSelection(
-                new SamSelectionRequest(new SamSelector(new SamIdentifier(AUTO, null, null))));
+
+                new SamSelectionRequest(new SamSelector.Builder()
+                        .samIdentifier(
+                                new SamIdentifier.SamIdentifierBuilder().samRevision(AUTO).build())
+                        .build()));
 
         SelectionsResult selectionsResult = null;
 

--- a/java/component/keyple-calypso/src/main/java/org/eclipse/keyple/calypso/transaction/SamResourceManager.java
+++ b/java/component/keyple-calypso/src/main/java/org/eclipse/keyple/calypso/transaction/SamResourceManager.java
@@ -19,6 +19,7 @@ import org.eclipse.keyple.core.seproxy.SeReader;
 import org.eclipse.keyple.core.seproxy.exception.KeypleAllocationReaderException;
 import org.eclipse.keyple.core.seproxy.exception.KeypleException;
 import org.eclipse.keyple.core.seproxy.exception.KeypleReaderException;
+import org.eclipse.keyple.core.seproxy.protocol.SeCommonProtocols;
 
 /**
  * Management of SAM resources:
@@ -87,9 +88,8 @@ public abstract class SamResourceManager {
         samSelection.prepareSelection(
 
                 new SamSelectionRequest(SamSelector.builder()
-                        .samIdentifier(
-                                new SamIdentifier.SamIdentifierBuilder().samRevision(AUTO).build())
-                        .build()));
+                        .seProtocol(SeCommonProtocols.PROTOCOL_ISO7816_3)
+                        .samIdentifier(SamIdentifier.builder().samRevision(AUTO).build()).build()));
 
         SelectionsResult selectionsResult = null;
 

--- a/java/component/keyple-calypso/src/main/java/org/eclipse/keyple/calypso/transaction/SamSelector.java
+++ b/java/component/keyple-calypso/src/main/java/org/eclipse/keyple/calypso/transaction/SamSelector.java
@@ -13,6 +13,7 @@ package org.eclipse.keyple.calypso.transaction;
 
 import org.eclipse.keyple.calypso.command.sam.SamRevision;
 import org.eclipse.keyple.core.seproxy.SeSelector;
+import org.eclipse.keyple.core.seproxy.protocol.SeProtocol;
 
 /**
  * The {@link SamSelector} class extends {@link SeSelector} to handle specific Calypso SAM needs
@@ -68,8 +69,7 @@ public class SamSelector extends SeSelector {
      * serial number and group reference</li>
      * </ul>
      */
-    protected abstract static class SamSelectorBuilder<T extends SamSelector.SamSelectorBuilder<T>>
-            extends SeSelector.SeSelectorBuilder<T> {
+    public static class SamSelectorBuilder extends SeSelector.SeSelectorBuilder {
         private SamRevision samRevision;
         private String serialNumber;
 
@@ -78,20 +78,35 @@ public class SamSelector extends SeSelector {
             this.atrFilter(new AtrFilter(""));
         }
 
-        public T samRevision(SamRevision samRevision) {
+        public SamSelectorBuilder samRevision(SamRevision samRevision) {
             this.samRevision = samRevision;
-            return self();
+            return this;
         }
 
-        public T serialNumber(String serialNumber) {
+        public SamSelectorBuilder serialNumber(String serialNumber) {
             this.serialNumber = serialNumber;
-            return self();
+            return this;
         }
 
-        public T samIdentifier(SamIdentifier samIdentifier) {
+        public SamSelectorBuilder samIdentifier(SamIdentifier samIdentifier) {
             samRevision = samIdentifier.getSamRevision();
             serialNumber = samIdentifier.getSerialNumber();
-            return self();
+            return this;
+        }
+
+        @Override
+        public SamSelectorBuilder seProtocol(SeProtocol seProtocol) {
+            return (SamSelectorBuilder) super.seProtocol(seProtocol);
+        }
+
+        @Override
+        public SamSelectorBuilder atrFilter(AtrFilter atrFilter) {
+            return (SamSelectorBuilder) super.atrFilter(atrFilter);
+        }
+
+        @Override
+        public SamSelectorBuilder aidSelector(AidSelector aidSelector) {
+            return (SamSelectorBuilder) super.aidSelector(aidSelector);
         }
 
         @Override
@@ -100,13 +115,7 @@ public class SamSelector extends SeSelector {
         }
     }
 
-    /**
-     * Gets a new builder.
-     */
-    public static class Builder extends SamSelector.SamSelectorBuilder<SamSelector.Builder> {
-        @Override
-        protected Builder self() {
-            return this;
-        }
+    public static SamSelectorBuilder builder() {
+        return new SamSelectorBuilder();
     }
 }

--- a/java/component/keyple-calypso/src/main/java/org/eclipse/keyple/calypso/transaction/SamSelector.java
+++ b/java/component/keyple-calypso/src/main/java/org/eclipse/keyple/calypso/transaction/SamSelector.java
@@ -57,17 +57,9 @@ public class SamSelector extends SeSelector {
     }
 
     /**
-     * Create a SeSelector to perform the SAM selection with<br>
-     * either
-     * <ul>
-     * <li>samRevision the {@link SamRevision} of the targeted SAM</li>
-     * <li>serialNumber the serial number of the targeted SAM as an hex string</li>
-     * </ul>
-     * or
-     * <ul>
-     * <li>samIdentifier the {@link SamIdentifier} object embedding the {@link SamRevision}, the
-     * serial number and group reference</li>
-     * </ul>
+     * Builder of {@link SamSelector}
+     * 
+     * @since 0.9
      */
     public static class SamSelectorBuilder extends SeSelector.SeSelectorBuilder {
         private SamRevision samRevision;
@@ -78,43 +70,80 @@ public class SamSelector extends SeSelector {
             this.atrFilter(new AtrFilter(""));
         }
 
+        /**
+         * Sets the SAM revision
+         * 
+         * @param samRevision the {@link SamRevision} of the targeted SAM
+         * @return the builder instance
+         */
         public SamSelectorBuilder samRevision(SamRevision samRevision) {
             this.samRevision = samRevision;
             return this;
         }
 
+        /**
+         * Sets the SAM serial number regex
+         * 
+         * @param serialNumber the serial number of the targeted SAM as regex
+         * @return the builder instance
+         */
         public SamSelectorBuilder serialNumber(String serialNumber) {
             this.serialNumber = serialNumber;
             return this;
         }
 
+        /**
+         * Sets the SAM identifier
+         * 
+         * @param samIdentifier the {@link SamIdentifier} of the targeted SAM
+         * @return the builder instance
+         */
         public SamSelectorBuilder samIdentifier(SamIdentifier samIdentifier) {
             samRevision = samIdentifier.getSamRevision();
             serialNumber = samIdentifier.getSerialNumber();
             return this;
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public SamSelectorBuilder seProtocol(SeProtocol seProtocol) {
             return (SamSelectorBuilder) super.seProtocol(seProtocol);
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public SamSelectorBuilder atrFilter(AtrFilter atrFilter) {
             return (SamSelectorBuilder) super.atrFilter(atrFilter);
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public SamSelectorBuilder aidSelector(AidSelector aidSelector) {
             return (SamSelectorBuilder) super.aidSelector(aidSelector);
         }
 
+        /**
+         * Build a new {@code SamSelector}.
+         *
+         * @return a new instance
+         */
         @Override
         public SamSelector build() {
             return new SamSelector(this);
         }
     }
 
+    /**
+     * Gets a new builder.
+     *
+     * @return a new builder instance
+     */
     public static SamSelectorBuilder builder() {
         return new SamSelectorBuilder();
     }

--- a/java/component/keyple-calypso/src/test/java/org/eclipse/keyple/calypso/transaction/CalypsoSamTest.java
+++ b/java/component/keyple-calypso/src/test/java/org/eclipse/keyple/calypso/transaction/CalypsoSamTest.java
@@ -36,7 +36,7 @@ public class CalypsoSamTest {
     /** basic CalypsoSam test: nominal ATR parsing */
     @Test
     public void test_CalypsoSam_1() {
-        SamSelector samSelector = new SamSelector(AUTO, null);
+        SamSelector samSelector = new SamSelector.Builder().samRevision(AUTO).build();
         SamSelectionRequest samSelectionRequest = new SamSelectionRequest(samSelector);
         SelectionStatus selectionStatus =
                 new SelectionStatus(new AnswerToReset(ByteArrayUtil.fromHex(ATR1)), null, true);
@@ -55,7 +55,7 @@ public class CalypsoSamTest {
     /* S1D D1 */
     @Test
     public void test_CalypsoSam_2() {
-        SamSelector samSelector = new SamSelector(AUTO, null);
+        SamSelector samSelector = new SamSelector.Builder().samRevision(AUTO).build();
         SamSelectionRequest samSelectionRequest = new SamSelectionRequest(samSelector);
         SelectionStatus selectionStatus =
                 new SelectionStatus(new AnswerToReset(ByteArrayUtil.fromHex(ATR2)), null, true);
@@ -68,7 +68,7 @@ public class CalypsoSamTest {
     /* S1D D2 */
     @Test
     public void test_CalypsoSam_3() {
-        SamSelector samSelector = new SamSelector(AUTO, null);
+        SamSelector samSelector = new SamSelector.Builder().samRevision(AUTO).build();
         SamSelectionRequest samSelectionRequest = new SamSelectionRequest(samSelector);
         SelectionStatus selectionStatus =
                 new SelectionStatus(new AnswerToReset(ByteArrayUtil.fromHex(ATR3)), null, true);
@@ -81,7 +81,7 @@ public class CalypsoSamTest {
     /* C1 */
     @Test
     public void test_CalypsoSam_4() {
-        SamSelector samSelector = new SamSelector(AUTO, null);
+        SamSelector samSelector = new SamSelector.Builder().samRevision(AUTO).build();
         SamSelectionRequest samSelectionRequest = new SamSelectionRequest(samSelector);
         SelectionStatus selectionStatus =
                 new SelectionStatus(new AnswerToReset(ByteArrayUtil.fromHex(ATR4)), null, true);
@@ -94,7 +94,7 @@ public class CalypsoSamTest {
     /* E1 */
     @Test
     public void test_CalypsoSam_5() {
-        SamSelector samSelector = new SamSelector(AUTO, null);
+        SamSelector samSelector = new SamSelector.Builder().samRevision(AUTO).build();
         SamSelectionRequest samSelectionRequest = new SamSelectionRequest(samSelector);
         SelectionStatus selectionStatus =
                 new SelectionStatus(new AnswerToReset(ByteArrayUtil.fromHex(ATR5)), null, true);
@@ -107,7 +107,7 @@ public class CalypsoSamTest {
     /* Unrecognized E2 */
     @Test(expected = IllegalStateException.class)
     public void test_CalypsoSam_6() {
-        SamSelector samSelector = new SamSelector(AUTO, null);
+        SamSelector samSelector = new SamSelector.Builder().samRevision(AUTO).build();
         SamSelectionRequest samSelectionRequest = new SamSelectionRequest(samSelector);
         SelectionStatus selectionStatus =
                 new SelectionStatus(new AnswerToReset(ByteArrayUtil.fromHex(ATR6)), null, true);
@@ -118,7 +118,7 @@ public class CalypsoSamTest {
     /* Bad Calypso SAM ATR (0000 instead of 9000) */
     @Test(expected = IllegalStateException.class)
     public void test_CalypsoSam_7() {
-        SamSelector samSelector = new SamSelector(AUTO, null);
+        SamSelector samSelector = new SamSelector.Builder().samRevision(AUTO).build();
         SamSelectionRequest samSelectionRequest = new SamSelectionRequest(samSelector);
         SelectionStatus selectionStatus =
                 new SelectionStatus(new AnswerToReset(ByteArrayUtil.fromHex(ATR7)), null, true);
@@ -129,7 +129,7 @@ public class CalypsoSamTest {
     /* Bad Calypso SAM ATR (empty array) */
     @Test(expected = IllegalStateException.class)
     public void test_CalypsoSam_8() {
-        SamSelector samSelector = new SamSelector(AUTO, null);
+        SamSelector samSelector = new SamSelector.Builder().samRevision(AUTO).build();
         SamSelectionRequest samSelectionRequest = new SamSelectionRequest(samSelector);
         SelectionStatus selectionStatus =
                 new SelectionStatus(new AnswerToReset(ByteArrayUtil.fromHex("")), null, true);

--- a/java/component/keyple-calypso/src/test/java/org/eclipse/keyple/calypso/transaction/CalypsoSamTest.java
+++ b/java/component/keyple-calypso/src/test/java/org/eclipse/keyple/calypso/transaction/CalypsoSamTest.java
@@ -36,7 +36,7 @@ public class CalypsoSamTest {
     /** basic CalypsoSam test: nominal ATR parsing */
     @Test
     public void test_CalypsoSam_1() {
-        SamSelector samSelector = new SamSelector.Builder().samRevision(AUTO).build();
+        SamSelector samSelector = SamSelector.builder().samRevision(AUTO).build();
         SamSelectionRequest samSelectionRequest = new SamSelectionRequest(samSelector);
         SelectionStatus selectionStatus =
                 new SelectionStatus(new AnswerToReset(ByteArrayUtil.fromHex(ATR1)), null, true);
@@ -55,7 +55,7 @@ public class CalypsoSamTest {
     /* S1D D1 */
     @Test
     public void test_CalypsoSam_2() {
-        SamSelector samSelector = new SamSelector.Builder().samRevision(AUTO).build();
+        SamSelector samSelector = SamSelector.builder().samRevision(AUTO).build();
         SamSelectionRequest samSelectionRequest = new SamSelectionRequest(samSelector);
         SelectionStatus selectionStatus =
                 new SelectionStatus(new AnswerToReset(ByteArrayUtil.fromHex(ATR2)), null, true);
@@ -68,7 +68,7 @@ public class CalypsoSamTest {
     /* S1D D2 */
     @Test
     public void test_CalypsoSam_3() {
-        SamSelector samSelector = new SamSelector.Builder().samRevision(AUTO).build();
+        SamSelector samSelector = SamSelector.builder().samRevision(AUTO).build();
         SamSelectionRequest samSelectionRequest = new SamSelectionRequest(samSelector);
         SelectionStatus selectionStatus =
                 new SelectionStatus(new AnswerToReset(ByteArrayUtil.fromHex(ATR3)), null, true);
@@ -81,7 +81,7 @@ public class CalypsoSamTest {
     /* C1 */
     @Test
     public void test_CalypsoSam_4() {
-        SamSelector samSelector = new SamSelector.Builder().samRevision(AUTO).build();
+        SamSelector samSelector = SamSelector.builder().samRevision(AUTO).build();
         SamSelectionRequest samSelectionRequest = new SamSelectionRequest(samSelector);
         SelectionStatus selectionStatus =
                 new SelectionStatus(new AnswerToReset(ByteArrayUtil.fromHex(ATR4)), null, true);
@@ -94,7 +94,7 @@ public class CalypsoSamTest {
     /* E1 */
     @Test
     public void test_CalypsoSam_5() {
-        SamSelector samSelector = new SamSelector.Builder().samRevision(AUTO).build();
+        SamSelector samSelector = SamSelector.builder().samRevision(AUTO).build();
         SamSelectionRequest samSelectionRequest = new SamSelectionRequest(samSelector);
         SelectionStatus selectionStatus =
                 new SelectionStatus(new AnswerToReset(ByteArrayUtil.fromHex(ATR5)), null, true);
@@ -107,7 +107,7 @@ public class CalypsoSamTest {
     /* Unrecognized E2 */
     @Test(expected = IllegalStateException.class)
     public void test_CalypsoSam_6() {
-        SamSelector samSelector = new SamSelector.Builder().samRevision(AUTO).build();
+        SamSelector samSelector = SamSelector.builder().samRevision(AUTO).build();
         SamSelectionRequest samSelectionRequest = new SamSelectionRequest(samSelector);
         SelectionStatus selectionStatus =
                 new SelectionStatus(new AnswerToReset(ByteArrayUtil.fromHex(ATR6)), null, true);
@@ -118,7 +118,7 @@ public class CalypsoSamTest {
     /* Bad Calypso SAM ATR (0000 instead of 9000) */
     @Test(expected = IllegalStateException.class)
     public void test_CalypsoSam_7() {
-        SamSelector samSelector = new SamSelector.Builder().samRevision(AUTO).build();
+        SamSelector samSelector = SamSelector.builder().samRevision(AUTO).build();
         SamSelectionRequest samSelectionRequest = new SamSelectionRequest(samSelector);
         SelectionStatus selectionStatus =
                 new SelectionStatus(new AnswerToReset(ByteArrayUtil.fromHex(ATR7)), null, true);
@@ -129,7 +129,7 @@ public class CalypsoSamTest {
     /* Bad Calypso SAM ATR (empty array) */
     @Test(expected = IllegalStateException.class)
     public void test_CalypsoSam_8() {
-        SamSelector samSelector = new SamSelector.Builder().samRevision(AUTO).build();
+        SamSelector samSelector = SamSelector.builder().samRevision(AUTO).build();
         SamSelectionRequest samSelectionRequest = new SamSelectionRequest(samSelector);
         SelectionStatus selectionStatus =
                 new SelectionStatus(new AnswerToReset(ByteArrayUtil.fromHex("")), null, true);

--- a/java/component/keyple-calypso/src/test/java/org/eclipse/keyple/calypso/transaction/PoSelectionRequestTest.java
+++ b/java/component/keyple-calypso/src/test/java/org/eclipse/keyple/calypso/transaction/PoSelectionRequestTest.java
@@ -50,7 +50,7 @@ public class PoSelectionRequestTest {
     @Before
     public void setUp() throws Exception {
         poSelectionRequest = new PoSelectionRequest(
-                new PoSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                PoSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
                         .atrFilter(new PoSelector.AtrFilter(".*"))
                         .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
     }

--- a/java/component/keyple-calypso/src/test/java/org/eclipse/keyple/calypso/transaction/PoSelectionRequestTest.java
+++ b/java/component/keyple-calypso/src/test/java/org/eclipse/keyple/calypso/transaction/PoSelectionRequestTest.java
@@ -49,9 +49,10 @@ public class PoSelectionRequestTest {
 
     @Before
     public void setUp() throws Exception {
-        poSelectionRequest =
-                new PoSelectionRequest(new PoSelector(SeCommonProtocols.PROTOCOL_ISO14443_4,
-                        new PoSelector.AtrFilter(".*"), null, PoSelector.InvalidatedPo.REJECT));
+        poSelectionRequest = new PoSelectionRequest(
+                new PoSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                        .atrFilter(new PoSelector.AtrFilter(".*"))
+                        .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
     }
 
     @Test

--- a/java/component/keyple-calypso/src/test/java/org/eclipse/keyple/calypso/transaction/SamResourceManagerDefaultTest.java
+++ b/java/component/keyple-calypso/src/test/java/org/eclipse/keyple/calypso/transaction/SamResourceManagerDefaultTest.java
@@ -60,8 +60,8 @@ public class SamResourceManagerDefaultTest extends CalypsoBaseTest {
         SamResource out = null;
         try {
             out = srmSpy.allocateSamResource(SamResourceManager.AllocationMode.BLOCKING,
-                    new SamIdentifier.SamIdentifierBuilder().samRevision(SamRevision.AUTO)
-                            .serialNumber("any").groupReference("any").build());
+                    SamIdentifier.builder().samRevision(SamRevision.AUTO).serialNumber("any")
+                            .groupReference("any").build());
 
         } catch (CalypsoNoSamResourceAvailableException e) {
             exceptionThrown = true;
@@ -86,8 +86,7 @@ public class SamResourceManagerDefaultTest extends CalypsoBaseTest {
 
         // test
         SamResource out = srmSpy.allocateSamResource(SamResourceManager.AllocationMode.BLOCKING,
-                SamIdentifier.builder().samRevision(SamRevision.AUTO).serialNumber("any")
-                        .groupReference("any").build());
+                SamIdentifier.builder().samRevision(SamRevision.AUTO).build());
 
         long stop = System.currentTimeMillis();
 

--- a/java/component/keyple-calypso/src/test/java/org/eclipse/keyple/calypso/transaction/SamResourceManagerDefaultTest.java
+++ b/java/component/keyple-calypso/src/test/java/org/eclipse/keyple/calypso/transaction/SamResourceManagerDefaultTest.java
@@ -86,7 +86,7 @@ public class SamResourceManagerDefaultTest extends CalypsoBaseTest {
 
         // test
         SamResource out = srmSpy.allocateSamResource(SamResourceManager.AllocationMode.BLOCKING,
-                new SamIdentifier.Builder().samRevision(SamRevision.AUTO).serialNumber("any")
+                SamIdentifier.builder().samRevision(SamRevision.AUTO).serialNumber("any")
                         .groupReference("any").build());
 
         long stop = System.currentTimeMillis();

--- a/java/component/keyple-calypso/src/test/java/org/eclipse/keyple/calypso/transaction/SamResourceManagerDefaultTest.java
+++ b/java/component/keyple-calypso/src/test/java/org/eclipse/keyple/calypso/transaction/SamResourceManagerDefaultTest.java
@@ -60,7 +60,8 @@ public class SamResourceManagerDefaultTest extends CalypsoBaseTest {
         SamResource out = null;
         try {
             out = srmSpy.allocateSamResource(SamResourceManager.AllocationMode.BLOCKING,
-                    new SamIdentifier(SamRevision.AUTO, "any", "any"));
+                    new SamIdentifier.SamIdentifierBuilder().samRevision(SamRevision.AUTO)
+                            .serialNumber("any").groupReference("any").build());
 
         } catch (CalypsoNoSamResourceAvailableException e) {
             exceptionThrown = true;
@@ -85,7 +86,8 @@ public class SamResourceManagerDefaultTest extends CalypsoBaseTest {
 
         // test
         SamResource out = srmSpy.allocateSamResource(SamResourceManager.AllocationMode.BLOCKING,
-                new SamIdentifier(SamRevision.AUTO, "any", "any"));
+                new SamIdentifier.Builder().samRevision(SamRevision.AUTO).serialNumber("any")
+                        .groupReference("any").build());
 
         long stop = System.currentTimeMillis();
 

--- a/java/component/keyple-calypso/src/test/java/org/eclipse/keyple/calypso/transaction/SamResourceManagerPoolTest.java
+++ b/java/component/keyple-calypso/src/test/java/org/eclipse/keyple/calypso/transaction/SamResourceManagerPoolTest.java
@@ -54,8 +54,8 @@ public class SamResourceManagerPoolTest extends CalypsoBaseTest {
         // test
         try {
             SamResource out = srmSpy.allocateSamResource(SamResourceManager.AllocationMode.BLOCKING,
-                    new SamIdentifier.SamIdentifierBuilder().samRevision(SamRevision.AUTO)
-                            .serialNumber("any").groupReference("any").build());
+                    SamIdentifier.builder().samRevision(SamRevision.AUTO).serialNumber("any")
+                            .groupReference("any").build());
 
         } catch (CalypsoNoSamResourceAvailableException e) {
             exceptionThrown = true;
@@ -84,8 +84,8 @@ public class SamResourceManagerPoolTest extends CalypsoBaseTest {
 
         // test
         SamResource out = srmSpy.allocateSamResource(SamResourceManager.AllocationMode.BLOCKING,
-                new SamIdentifier.SamIdentifierBuilder().samRevision(SamRevision.AUTO)
-                        .serialNumber("any").groupReference("any").build());
+                SamIdentifier.builder().samRevision(SamRevision.AUTO).serialNumber("any")
+                        .groupReference("any").build());
 
         long stop = System.currentTimeMillis();
 

--- a/java/component/keyple-calypso/src/test/java/org/eclipse/keyple/calypso/transaction/SamResourceManagerPoolTest.java
+++ b/java/component/keyple-calypso/src/test/java/org/eclipse/keyple/calypso/transaction/SamResourceManagerPoolTest.java
@@ -54,7 +54,8 @@ public class SamResourceManagerPoolTest extends CalypsoBaseTest {
         // test
         try {
             SamResource out = srmSpy.allocateSamResource(SamResourceManager.AllocationMode.BLOCKING,
-                    new SamIdentifier(SamRevision.AUTO, "any", "any"));
+                    new SamIdentifier.SamIdentifierBuilder().samRevision(SamRevision.AUTO)
+                            .serialNumber("any").groupReference("any").build());
 
         } catch (CalypsoNoSamResourceAvailableException e) {
             exceptionThrown = true;
@@ -83,7 +84,8 @@ public class SamResourceManagerPoolTest extends CalypsoBaseTest {
 
         // test
         SamResource out = srmSpy.allocateSamResource(SamResourceManager.AllocationMode.BLOCKING,
-                new SamIdentifier(SamRevision.AUTO, "any", "any"));
+                new SamIdentifier.SamIdentifierBuilder().samRevision(SamRevision.AUTO)
+                        .serialNumber("any").groupReference("any").build());
 
         long stop = System.currentTimeMillis();
 

--- a/java/component/keyple-calypso/src/test/java/org/eclipse/keyple/calypso/transaction/SamSelectorTest.java
+++ b/java/component/keyple-calypso/src/test/java/org/eclipse/keyple/calypso/transaction/SamSelectorTest.java
@@ -19,7 +19,7 @@ public class SamSelectorTest {
 
     @Test
     public void test_AidSelectorNull() {
-        SamSelector samSelector = new SamSelector.Builder().samIdentifier(
+        SamSelector samSelector = SamSelector.builder().samIdentifier(
                 new SamIdentifier.SamIdentifierBuilder().samRevision(SamRevision.S1D).build())
                 .build();
         assertNull(samSelector.getAidSelector());
@@ -27,7 +27,7 @@ public class SamSelectorTest {
 
     @Test
     public void test_SamRevision_S1D() {
-        SamSelector samSelector = new SamSelector.Builder().samIdentifier(
+        SamSelector samSelector = SamSelector.builder().samIdentifier(
                 new SamIdentifier.SamIdentifierBuilder().samRevision(SamRevision.S1D).build())
                 .build();
         assertEquals("3B(.{6}|.{10})805A..80D?20.{4}.{8}829000",
@@ -36,7 +36,7 @@ public class SamSelectorTest {
 
     @Test
     public void test_SamRevision_S1E() {
-        SamSelector samSelector = new SamSelector.Builder().samIdentifier(
+        SamSelector samSelector = SamSelector.builder().samIdentifier(
                 new SamIdentifier.SamIdentifierBuilder().samRevision(SamRevision.S1E).build())
                 .build();
         assertEquals("3B(.{6}|.{10})805A..80E120.{4}.{8}829000",
@@ -45,7 +45,7 @@ public class SamSelectorTest {
 
     @Test
     public void test_SamRevision_C1() {
-        SamSelector samSelector = new SamSelector.Builder().samIdentifier(
+        SamSelector samSelector = SamSelector.builder().samIdentifier(
                 new SamIdentifier.SamIdentifierBuilder().samRevision(SamRevision.C1).build())
                 .build();
         assertEquals("3B(.{6}|.{10})805A..80C120.{4}.{8}829000",
@@ -54,8 +54,8 @@ public class SamSelectorTest {
 
     @Test
     public void test_SamRevision_ANY() {
-        SamSelector samSelector = new SamSelector.Builder().samIdentifier(
-                new SamIdentifier.SamIdentifierBuilder().samRevision(SamRevision.S1D).build())
+        SamSelector samSelector = SamSelector.builder().samIdentifier(
+                new SamIdentifier.SamIdentifierBuilder().samRevision(SamRevision.AUTO).build())
                 .build();
         assertEquals(".*", samSelector.getAtrFilter().getAtrRegex());
     }
@@ -63,7 +63,7 @@ public class SamSelectorTest {
     @Test
     public void test_SamSerialNumber() {
         SamSelector samSelector =
-                new SamSelector.Builder()
+                SamSelector.builder()
                         .samIdentifier(new SamIdentifier.SamIdentifierBuilder()
                                 .samRevision(SamRevision.C1).serialNumber("11223344").build())
                         .build();

--- a/java/component/keyple-calypso/src/test/java/org/eclipse/keyple/calypso/transaction/SamSelectorTest.java
+++ b/java/component/keyple-calypso/src/test/java/org/eclipse/keyple/calypso/transaction/SamSelectorTest.java
@@ -19,41 +19,54 @@ public class SamSelectorTest {
 
     @Test
     public void test_AidSelectorNull() {
-        SamSelector samSelector = new SamSelector(new SamIdentifier(SamRevision.S1D, "", ""));
+        SamSelector samSelector = new SamSelector.Builder().samIdentifier(
+                new SamIdentifier.SamIdentifierBuilder().samRevision(SamRevision.S1D).build())
+                .build();
         assertNull(samSelector.getAidSelector());
     }
 
     @Test
     public void test_SamRevision_S1D() {
-        SamSelector samSelector = new SamSelector(new SamIdentifier(SamRevision.S1D, "", ""));
+        SamSelector samSelector = new SamSelector.Builder().samIdentifier(
+                new SamIdentifier.SamIdentifierBuilder().samRevision(SamRevision.S1D).build())
+                .build();
         assertEquals("3B(.{6}|.{10})805A..80D?20.{4}.{8}829000",
                 samSelector.getAtrFilter().getAtrRegex());
     }
 
     @Test
     public void test_SamRevision_S1E() {
-        SamSelector samSelector = new SamSelector(new SamIdentifier(SamRevision.S1E, "", ""));
+        SamSelector samSelector = new SamSelector.Builder().samIdentifier(
+                new SamIdentifier.SamIdentifierBuilder().samRevision(SamRevision.S1E).build())
+                .build();
         assertEquals("3B(.{6}|.{10})805A..80E120.{4}.{8}829000",
                 samSelector.getAtrFilter().getAtrRegex());
     }
 
     @Test
     public void test_SamRevision_C1() {
-        SamSelector samSelector = new SamSelector(new SamIdentifier(SamRevision.C1, "", ""));
+        SamSelector samSelector = new SamSelector.Builder().samIdentifier(
+                new SamIdentifier.SamIdentifierBuilder().samRevision(SamRevision.C1).build())
+                .build();
         assertEquals("3B(.{6}|.{10})805A..80C120.{4}.{8}829000",
                 samSelector.getAtrFilter().getAtrRegex());
     }
 
     @Test
     public void test_SamRevision_ANY() {
-        SamSelector samSelector = new SamSelector(new SamIdentifier(SamRevision.AUTO, "", ""));
+        SamSelector samSelector = new SamSelector.Builder().samIdentifier(
+                new SamIdentifier.SamIdentifierBuilder().samRevision(SamRevision.S1D).build())
+                .build();
         assertEquals(".*", samSelector.getAtrFilter().getAtrRegex());
     }
 
     @Test
     public void test_SamSerialNumber() {
         SamSelector samSelector =
-                new SamSelector(new SamIdentifier(SamRevision.C1, "11223344", ""));
+                new SamSelector.Builder()
+                        .samIdentifier(new SamIdentifier.SamIdentifierBuilder()
+                                .samRevision(SamRevision.C1).serialNumber("11223344").build())
+                        .build();
         assertEquals("3B(.{6}|.{10})805A..80C120.{4}11223344829000",
                 samSelector.getAtrFilter().getAtrRegex());
     }

--- a/java/component/keyple-calypso/src/test/java/org/eclipse/keyple/calypso/transaction/SamSelectorTest.java
+++ b/java/component/keyple-calypso/src/test/java/org/eclipse/keyple/calypso/transaction/SamSelectorTest.java
@@ -19,16 +19,16 @@ public class SamSelectorTest {
 
     @Test
     public void test_AidSelectorNull() {
-        SamSelector samSelector = SamSelector.builder().samIdentifier(
-                new SamIdentifier.SamIdentifierBuilder().samRevision(SamRevision.S1D).build())
+        SamSelector samSelector = SamSelector.builder()
+                .samIdentifier(SamIdentifier.builder().samRevision(SamRevision.S1D).build())
                 .build();
         assertNull(samSelector.getAidSelector());
     }
 
     @Test
     public void test_SamRevision_S1D() {
-        SamSelector samSelector = SamSelector.builder().samIdentifier(
-                new SamIdentifier.SamIdentifierBuilder().samRevision(SamRevision.S1D).build())
+        SamSelector samSelector = SamSelector.builder()
+                .samIdentifier(SamIdentifier.builder().samRevision(SamRevision.S1D).build())
                 .build();
         assertEquals("3B(.{6}|.{10})805A..80D?20.{4}.{8}829000",
                 samSelector.getAtrFilter().getAtrRegex());
@@ -36,8 +36,8 @@ public class SamSelectorTest {
 
     @Test
     public void test_SamRevision_S1E() {
-        SamSelector samSelector = SamSelector.builder().samIdentifier(
-                new SamIdentifier.SamIdentifierBuilder().samRevision(SamRevision.S1E).build())
+        SamSelector samSelector = SamSelector.builder()
+                .samIdentifier(SamIdentifier.builder().samRevision(SamRevision.S1E).build())
                 .build();
         assertEquals("3B(.{6}|.{10})805A..80E120.{4}.{8}829000",
                 samSelector.getAtrFilter().getAtrRegex());
@@ -45,17 +45,16 @@ public class SamSelectorTest {
 
     @Test
     public void test_SamRevision_C1() {
-        SamSelector samSelector = SamSelector.builder().samIdentifier(
-                new SamIdentifier.SamIdentifierBuilder().samRevision(SamRevision.C1).build())
-                .build();
+        SamSelector samSelector = SamSelector.builder()
+                .samIdentifier(SamIdentifier.builder().samRevision(SamRevision.C1).build()).build();
         assertEquals("3B(.{6}|.{10})805A..80C120.{4}.{8}829000",
                 samSelector.getAtrFilter().getAtrRegex());
     }
 
     @Test
     public void test_SamRevision_ANY() {
-        SamSelector samSelector = SamSelector.builder().samIdentifier(
-                new SamIdentifier.SamIdentifierBuilder().samRevision(SamRevision.AUTO).build())
+        SamSelector samSelector = SamSelector.builder()
+                .samIdentifier(SamIdentifier.builder().samRevision(SamRevision.AUTO).build())
                 .build();
         assertEquals(".*", samSelector.getAtrFilter().getAtrRegex());
     }

--- a/java/component/keyple-core/src/main/java/org/eclipse/keyple/core/selection/SelectionsResult.java
+++ b/java/component/keyple-core/src/main/java/org/eclipse/keyple/core/selection/SelectionsResult.java
@@ -96,14 +96,14 @@ public final class SelectionsResult {
      * @param selectionIndex the selection index
      * @return true if the selection has matched
      */
-    boolean hasSelectionMatched(int selectionIndex) {
+    public boolean hasSelectionMatched(int selectionIndex) {
         return matchingSeMap.containsKey(selectionIndex);
     }
 
     /**
      * @return the index of the active selection
      */
-    int getActiveSelectionIndex() {
+    public int getActiveSelectionIndex() {
         if (hasActiveSelection()) {
             return activeSelectionIndex;
         }

--- a/java/component/keyple-core/src/main/java/org/eclipse/keyple/core/seproxy/SeSelector.java
+++ b/java/component/keyple-core/src/main/java/org/eclipse/keyple/core/seproxy/SeSelector.java
@@ -108,7 +108,7 @@ public class SeSelector {
 
         /**
          * Builder of {@link AidSelector}
-         * 
+         *
          * @since 0.9
          */
         public static class AidSelectorBuilder {
@@ -121,7 +121,7 @@ public class SeSelector {
 
             /**
              * Sets the AID
-             * 
+             *
              * @param aid the AID as an array of bytes
              * @return the builder instance
              */
@@ -138,7 +138,7 @@ public class SeSelector {
 
             /**
              * Sets the AID
-             * 
+             *
              * @param aid the AID as an hex string
              * @return the builder instance
              */
@@ -148,7 +148,7 @@ public class SeSelector {
 
             /**
              * Sets the file occurence mode (see ISO7816-4)
-             * 
+             *
              * @param fileOccurrence the {@link FileOccurrence}
              * @return the builder instance
              */
@@ -160,7 +160,7 @@ public class SeSelector {
 
             /**
              * Sets the file control mode (see ISO7816-4)
-             * 
+             *
              * @param fileControlInformation the {@link FileControlInformation}
              * @return the builder instance
              */
@@ -317,7 +317,7 @@ public class SeSelector {
 
     /**
      * Private constructor
-     * 
+     *
      * @param builder the SeSelector builder
      */
     protected SeSelector(SeSelectorBuilder builder) {
@@ -334,7 +334,7 @@ public class SeSelector {
 
     /**
      * Create a SeSelector to perform the SE selection<br>
-     * 
+     *
      * @since 0.9
      */
     public static class SeSelectorBuilder {
@@ -348,7 +348,7 @@ public class SeSelector {
 
         /**
          * Sets the SE protocol
-         * 
+         *
          * @param seProtocol the {@link SeProtocol} of the targeted SE
          * @return the builder instance
          */
@@ -359,7 +359,7 @@ public class SeSelector {
 
         /**
          * Sets the SE ATR Filter
-         * 
+         *
          * @param atrFilter the {@link AtrFilter} of the targeted SE
          * @return the builder instance
          */
@@ -370,7 +370,7 @@ public class SeSelector {
 
         /**
          * Sets the SE AID Selector
-         * 
+         *
          * @param aidSelector the {@link AidSelector} of the targeted SE
          * @return the builder instance
          */

--- a/java/component/keyple-core/src/main/java/org/eclipse/keyple/core/seproxy/SeSelector.java
+++ b/java/component/keyple-core/src/main/java/org/eclipse/keyple/core/seproxy/SeSelector.java
@@ -162,11 +162,11 @@ public class SeSelector {
 
         /**
          * Gets a new builder.
+         *
+         * @return a new builder instance
          */
-        public static class Builder extends AidSelectorBuilder {
-            protected Builder self() {
-                return this;
-            }
+        public static AidSelectorBuilder builder() {
+            return new AidSelectorBuilder();
         }
 
         /**
@@ -337,29 +337,28 @@ public class SeSelector {
      *
      * @since 0.9
      */
-    public abstract static class SeSelectorBuilder<T extends SeSelectorBuilder<T>> {
-        private SeProtocol seProtocol;
-        private SeSelector.AtrFilter atrFilter;
-        private SeSelector.AidSelector aidSelector;
+    public static class SeSelectorBuilder {
+        SeProtocol seProtocol;
+        SeSelector.AtrFilter atrFilter;
+        SeSelector.AidSelector aidSelector;
 
-        protected abstract T self();
 
         /** Private constructor */
         protected SeSelectorBuilder() {}
 
-        public T seProtocol(SeProtocol seProtocol) {
+        public SeSelectorBuilder seProtocol(SeProtocol seProtocol) {
             this.seProtocol = seProtocol;
-            return self();
+            return this;
         }
 
-        public T atrFilter(SeSelector.AtrFilter atrFilter) {
+        public SeSelectorBuilder atrFilter(SeSelector.AtrFilter atrFilter) {
             this.atrFilter = atrFilter;
-            return self();
+            return this;
         }
 
-        public T aidSelector(SeSelector.AidSelector aidSelector) {
+        public SeSelectorBuilder aidSelector(SeSelector.AidSelector aidSelector) {
             this.aidSelector = aidSelector;
-            return self();
+            return this;
         }
 
         public SeSelector build() {
@@ -367,14 +366,8 @@ public class SeSelector {
         }
     }
 
-    /**
-     * Gets a new builder.
-     */
-    public static class Builder extends SeSelectorBuilder<Builder> {
-        @Override
-        protected Builder self() {
-            return this;
-        }
+    public static SeSelectorBuilder builder() {
+        return new SeSelectorBuilder();
     }
 
     /**

--- a/java/component/keyple-core/src/main/java/org/eclipse/keyple/core/seproxy/SeSelector.java
+++ b/java/component/keyple-core/src/main/java/org/eclipse/keyple/core/seproxy/SeSelector.java
@@ -107,17 +107,8 @@ public class SeSelector {
         }
 
         /**
-         * (package-private)<br>
-         * Builder class to create a AidSelector with additional file occurrence and file control
-         * information.
-         * <p>
-         * The fileOccurrence parameter defines the selection options P2 of the SELECT command
-         * message
-         * <p>
-         * The fileControlInformation parameter defines the expected command output template.
-         * <p>
-         * Refer to ISO7816-4.2 for detailed information about these parameters
-         *
+         * Builder of {@link AidSelector}
+         * 
          * @since 0.9
          */
         public static class AidSelectorBuilder {
@@ -128,6 +119,12 @@ public class SeSelector {
             /** Private constructor */
             private AidSelectorBuilder() {}
 
+            /**
+             * Sets the AID
+             * 
+             * @param aid the AID as an array of bytes
+             * @return the builder instance
+             */
             public AidSelectorBuilder aidToSelect(byte[] aid) {
                 if (aid.length < AID_MIN_LENGTH || aid.length > AID_MAX_LENGTH) {
                     aidToSelect = null;
@@ -139,22 +136,45 @@ public class SeSelector {
                 return this;
             }
 
+            /**
+             * Sets the AID
+             * 
+             * @param aid the AID as an hex string
+             * @return the builder instance
+             */
             public AidSelectorBuilder aidToSelect(String aid) {
                 return this.aidToSelect(ByteArrayUtil.fromHex(aid));
             }
 
+            /**
+             * Sets the file occurence mode (see ISO7816-4)
+             * 
+             * @param fileOccurrence the {@link FileOccurrence}
+             * @return the builder instance
+             */
             public AidSelectorBuilder fileOccurrence(
                     SeSelector.AidSelector.FileOccurrence fileOccurrence) {
                 this.fileOccurrence = fileOccurrence;
                 return this;
             }
 
+            /**
+             * Sets the file control mode (see ISO7816-4)
+             * 
+             * @param fileControlInformation the {@link FileControlInformation}
+             * @return the builder instance
+             */
             public AidSelectorBuilder fileControlInformation(
                     SeSelector.AidSelector.FileControlInformation fileControlInformation) {
                 this.fileControlInformation = fileControlInformation;
                 return this;
             }
 
+            /**
+             * Build a new {@code AidSelector}.
+             *
+             * @return a new instance
+             */
             public SeSelector.AidSelector build() {
                 return new SeSelector.AidSelector(this);
             }
@@ -314,27 +334,7 @@ public class SeSelector {
 
     /**
      * Create a SeSelector to perform the SE selection<br>
-     * Builder pattern with inheritance inspired from https://stackoverflow.com/a/52294689
-     * <p>
-     * if seProtocol is null, all protocols will match and the selection process will continue
-     *
-     * <p>
-     * if seProtocol is not null, the current SE protocol will checked and the selection process
-     * will continue only if the protocol matches.
-     *
-     * <p>
-     * if aidSelector is null, no 'select application' command is generated. In this case the SE
-     * must have a default application selected. (e.g. SAM or Rev1 Calypso cards)
-     * <p>
-     * if aidSelector is not null, a 'select application' command is generated and performed.
-     * Furthermore, the status code is checked against the list of successful status codes in the
-     * {@link AidSelector} to determine if the SE matched or not the selection data.
-     * <p>
-     * if atrFilter is null, no check of the ATR is performed. All SE will match.
-     * <p>
-     * if atrFilter is not null, the ATR of the SE is compared with the regular expression provided
-     * in the {@link AtrFilter} in order to determine if the SE match or not the expected ATR.
-     *
+     * 
      * @since 0.9
      */
     public static class SeSelectorBuilder {
@@ -346,26 +346,54 @@ public class SeSelector {
         /** Private constructor */
         protected SeSelectorBuilder() {}
 
+        /**
+         * Sets the SE protocol
+         * 
+         * @param seProtocol the {@link SeProtocol} of the targeted SE
+         * @return the builder instance
+         */
         public SeSelectorBuilder seProtocol(SeProtocol seProtocol) {
             this.seProtocol = seProtocol;
             return this;
         }
 
+        /**
+         * Sets the SE ATR Filter
+         * 
+         * @param atrFilter the {@link AtrFilter} of the targeted SE
+         * @return the builder instance
+         */
         public SeSelectorBuilder atrFilter(SeSelector.AtrFilter atrFilter) {
             this.atrFilter = atrFilter;
             return this;
         }
 
+        /**
+         * Sets the SE AID Selector
+         * 
+         * @param aidSelector the {@link AidSelector} of the targeted SE
+         * @return the builder instance
+         */
         public SeSelectorBuilder aidSelector(SeSelector.AidSelector aidSelector) {
             this.aidSelector = aidSelector;
             return this;
         }
 
+        /**
+         * Build a new {@code SeSelector}.
+         *
+         * @return a new instance
+         */
         public SeSelector build() {
             return new SeSelector(this);
         }
     }
 
+    /**
+     * Gets a new builder.
+     *
+     * @return a new builder instance
+     */
     public static SeSelectorBuilder builder() {
         return new SeSelectorBuilder();
     }

--- a/java/component/keyple-core/src/test/java/org/eclipse/keyple/core/selection/SeSelectionTest.java
+++ b/java/component/keyple-core/src/test/java/org/eclipse/keyple/core/selection/SeSelectionTest.java
@@ -69,10 +69,10 @@ public class SeSelectionTest extends CoreBaseTest {
         SeRequest seRequest2 = iterator.next();
 
         // check selectors
-        Assert.assertEquals("AABBCCDDEE", ByteArrayUtil
-                .toHex(seRequest1.getSeSelector().getAidSelector().getAidToSelect().getValue()));
-        Assert.assertEquals("1122334455", ByteArrayUtil
-                .toHex(seRequest2.getSeSelector().getAidSelector().getAidToSelect().getValue()));
+        Assert.assertEquals("AABBCCDDEE",
+                ByteArrayUtil.toHex(seRequest1.getSeSelector().getAidSelector().getAidToSelect()));
+        Assert.assertEquals("1122334455",
+                ByteArrayUtil.toHex(seRequest2.getSeSelector().getAidSelector().getAidToSelect()));
 
         Assert.assertEquals(SeSelector.AidSelector.FileOccurrence.FIRST,
                 seRequest1.getSeSelector().getAidSelector().getFileOccurrence());
@@ -105,8 +105,8 @@ public class SeSelectionTest extends CoreBaseTest {
         Assert.assertArrayEquals(apduRequests.get(1).getBytes(),
                 ByteArrayUtil.fromHex("66778899AABB"));
 
-        Assert.assertEquals(apduRequests.get(0).isCase4(), false);
-        Assert.assertEquals(apduRequests.get(1).isCase4(), true);
+        Assert.assertFalse(apduRequests.get(0).isCase4());
+        Assert.assertTrue(apduRequests.get(1).isCase4());
 
         // that's all!
     }
@@ -248,12 +248,12 @@ public class SeSelectionTest extends CoreBaseTest {
         SeSelection seSelection = new SeSelection();
 
         // create and add two selection cases
-        SeSelector.AidSelector aidSelector =
-                new SeSelector.AidSelector(new SeSelector.AidSelector.IsoAid("AABBCCDDEE"),
-                        SeSelector.AidSelector.FileOccurrence.FIRST,
-                        SeSelector.AidSelector.FileControlInformation.FCI);
-        SeSelector seSelector1 =
-                new SeSelector(SeCommonProtocols.PROTOCOL_ISO14443_4, null, aidSelector);
+        SeSelector.AidSelector aidSelector = new SeSelector.AidSelector.Builder()
+                .aidToSelect("AABBCCDDEE")
+                .fileOccurrence(SeSelector.AidSelector.FileOccurrence.FIRST)
+                .fileControlInformation(SeSelector.AidSelector.FileControlInformation.FCI).build();
+        SeSelector seSelector1 = new SeSelector.Builder()
+                .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4).aidSelector(aidSelector).build();
 
         // APDU requests
         List<AbstractApduCommandBuilder> commandBuilders =
@@ -265,13 +265,14 @@ public class SeSelectionTest extends CoreBaseTest {
 
         seSelection.prepareSelection(new SeSelectionRequest(seSelector1, commandBuilders));
 
-        aidSelector = new SeSelector.AidSelector(new SeSelector.AidSelector.IsoAid("1122334455"),
-                SeSelector.AidSelector.FileOccurrence.NEXT,
-                SeSelector.AidSelector.FileControlInformation.FCP);
+        aidSelector = new SeSelector.AidSelector.Builder().aidToSelect("1122334455")
+                .fileOccurrence(SeSelector.AidSelector.FileOccurrence.NEXT)
+                .fileControlInformation(SeSelector.AidSelector.FileControlInformation.FCP).build();
         aidSelector.addSuccessfulStatusCode(0x6283);
 
-        SeSelector seSelector2 = new SeSelector(SeCommonProtocols.PROTOCOL_B_PRIME,
-                new SeSelector.AtrFilter(".*"), aidSelector);
+        SeSelector seSelector2 =
+                new SeSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_B_PRIME)
+                        .atrFilter(new SeSelector.AtrFilter(".*")).aidSelector(aidSelector).build();
 
         seSelection.prepareSelection(new SeSelectionRequest(seSelector2, null));
 

--- a/java/component/keyple-core/src/test/java/org/eclipse/keyple/core/selection/SeSelectionTest.java
+++ b/java/component/keyple-core/src/test/java/org/eclipse/keyple/core/selection/SeSelectionTest.java
@@ -248,11 +248,11 @@ public class SeSelectionTest extends CoreBaseTest {
         SeSelection seSelection = new SeSelection();
 
         // create and add two selection cases
-        SeSelector.AidSelector aidSelector = new SeSelector.AidSelector.Builder()
+        SeSelector.AidSelector aidSelector = SeSelector.AidSelector.builder()
                 .aidToSelect("AABBCCDDEE")
                 .fileOccurrence(SeSelector.AidSelector.FileOccurrence.FIRST)
                 .fileControlInformation(SeSelector.AidSelector.FileControlInformation.FCI).build();
-        SeSelector seSelector1 = new SeSelector.Builder()
+        SeSelector seSelector1 = SeSelector.builder()
                 .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4).aidSelector(aidSelector).build();
 
         // APDU requests
@@ -265,14 +265,13 @@ public class SeSelectionTest extends CoreBaseTest {
 
         seSelection.prepareSelection(new SeSelectionRequest(seSelector1, commandBuilders));
 
-        aidSelector = new SeSelector.AidSelector.Builder().aidToSelect("1122334455")
+        aidSelector = SeSelector.AidSelector.builder().aidToSelect("1122334455")
                 .fileOccurrence(SeSelector.AidSelector.FileOccurrence.NEXT)
                 .fileControlInformation(SeSelector.AidSelector.FileControlInformation.FCP).build();
         aidSelector.addSuccessfulStatusCode(0x6283);
 
-        SeSelector seSelector2 =
-                new SeSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_B_PRIME)
-                        .atrFilter(new SeSelector.AtrFilter(".*")).aidSelector(aidSelector).build();
+        SeSelector seSelector2 = SeSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_B_PRIME)
+                .atrFilter(new SeSelector.AtrFilter(".*")).aidSelector(aidSelector).build();
 
         seSelection.prepareSelection(new SeSelectionRequest(seSelector2, null));
 

--- a/java/component/keyple-core/src/test/java/org/eclipse/keyple/core/seproxy/message/SeRequestTest.java
+++ b/java/component/keyple-core/src/test/java/org/eclipse/keyple/core/seproxy/message/SeRequestTest.java
@@ -171,14 +171,14 @@ public class SeRequestTest {
          * test is to verify the proper format of the request.
          */
         SeSelector.AidSelector aidSelector =
-                new SeSelector.AidSelector.Builder().aidToSelect("AABBCCDDEEFF").build();
+                SeSelector.AidSelector.builder().aidToSelect("AABBCCDDEEFF").build();
         if (selectionStatusCode != null) {
             for (int statusCode : selectionStatusCode) {
                 aidSelector.addSuccessfulStatusCode(statusCode);
             }
         }
-        SeSelector seSelector = new SeSelector.Builder().seProtocol(getASeProtocol())
-                .aidSelector(aidSelector).build();
+        SeSelector seSelector =
+                SeSelector.builder().seProtocol(getASeProtocol()).aidSelector(aidSelector).build();
         return seSelector;
     }
 

--- a/java/component/keyple-core/src/test/java/org/eclipse/keyple/core/seproxy/message/SeRequestTest.java
+++ b/java/component/keyple-core/src/test/java/org/eclipse/keyple/core/seproxy/message/SeRequestTest.java
@@ -18,7 +18,6 @@ import java.util.Set;
 import org.eclipse.keyple.core.seproxy.SeSelector;
 import org.eclipse.keyple.core.seproxy.protocol.SeCommonProtocols;
 import org.eclipse.keyple.core.seproxy.protocol.SeProtocol;
-import org.eclipse.keyple.core.util.ByteArrayUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -171,14 +170,15 @@ public class SeRequestTest {
          * We can use a fake AID here because it is not fully interpreted, the purpose of this unit
          * test is to verify the proper format of the request.
          */
-        SeSelector.AidSelector aidSelector = new SeSelector.AidSelector(
-                new SeSelector.AidSelector.IsoAid(ByteArrayUtil.fromHex("AABBCCDDEEFF")));
+        SeSelector.AidSelector aidSelector =
+                new SeSelector.AidSelector.Builder().aidToSelect("AABBCCDDEEFF").build();
         if (selectionStatusCode != null) {
             for (int statusCode : selectionStatusCode) {
                 aidSelector.addSuccessfulStatusCode(statusCode);
             }
         }
-        SeSelector seSelector = new SeSelector(getASeProtocol(), null, aidSelector);
+        SeSelector seSelector = new SeSelector.Builder().seProtocol(getASeProtocol())
+                .aidSelector(aidSelector).build();
         return seSelector;
     }
 

--- a/java/component/keyple-core/src/test/java/org/eclipse/keyple/core/seproxy/plugin/local/AbsLocalReaderSelectionTest.java
+++ b/java/component/keyple-core/src/test/java/org/eclipse/keyple/core/seproxy/plugin/local/AbsLocalReaderSelectionTest.java
@@ -191,13 +191,13 @@ public class AbsLocalReaderSelectionTest extends CoreBaseTest {
 
         SeSelector.AtrFilter atrFilter = new SeSelector.AtrFilter(ATR);
         SeSelector.AidSelector aidSelector =
-                new SeSelector.AidSelector.Builder().aidToSelect(AID).build();
+                SeSelector.AidSelector.builder().aidToSelect(AID).build();
         aidSelector.addSuccessfulStatusCode(STATUS_CODE_1);
         aidSelector.addSuccessfulStatusCode(STATUS_CODE_2);
 
         // select both
         SeSelector seSelector =
-                new SeSelector.Builder().atrFilter(atrFilter).aidSelector(aidSelector).build();
+                SeSelector.builder().atrFilter(atrFilter).aidSelector(aidSelector).build();
 
         SelectionStatus status = r.openLogicalChannel(seSelector);
         Assert.assertEquals(true, status.hasMatched());
@@ -212,7 +212,7 @@ public class AbsLocalReaderSelectionTest extends CoreBaseTest {
     public void select_no_param() throws Exception {
         AbstractLocalReader r = getSpy(PLUGIN_NAME, READER_NAME);
 
-        SeSelector seSelector = new SeSelector.Builder().build();
+        SeSelector seSelector = SeSelector.builder().build();
 
         SelectionStatus status = r.openLogicalChannel(seSelector);
         Assert.assertEquals(true, status.hasMatched());
@@ -308,18 +308,18 @@ public class AbsLocalReaderSelectionTest extends CoreBaseTest {
 
     public static SeSelector getAidSelector() {
         SeSelector.AidSelector aidSelector =
-                new SeSelector.AidSelector.Builder().aidToSelect(AID).build();
+                SeSelector.AidSelector.builder().aidToSelect(AID).build();
         aidSelector.addSuccessfulStatusCode(STATUS_CODE_1);
         aidSelector.addSuccessfulStatusCode(STATUS_CODE_2);
 
-        return new SeSelector.Builder().aidSelector(aidSelector).build();
+        return SeSelector.builder().aidSelector(aidSelector).build();
     }
 
     public static SeSelector getAtrSelector() {
 
         SeSelector.AtrFilter atrFilter = new SeSelector.AtrFilter(ATR);
 
-        return new SeSelector.Builder().atrFilter(atrFilter).build();
+        return SeSelector.builder().atrFilter(atrFilter).build();
     }
 
 

--- a/java/component/keyple-core/src/test/java/org/eclipse/keyple/core/seproxy/plugin/local/AbsLocalReaderSelectionTest.java
+++ b/java/component/keyple-core/src/test/java/org/eclipse/keyple/core/seproxy/plugin/local/AbsLocalReaderSelectionTest.java
@@ -191,12 +191,13 @@ public class AbsLocalReaderSelectionTest extends CoreBaseTest {
 
         SeSelector.AtrFilter atrFilter = new SeSelector.AtrFilter(ATR);
         SeSelector.AidSelector aidSelector =
-                new SeSelector.AidSelector(new SeSelector.AidSelector.IsoAid(AID));
+                new SeSelector.AidSelector.Builder().aidToSelect(AID).build();
         aidSelector.addSuccessfulStatusCode(STATUS_CODE_1);
         aidSelector.addSuccessfulStatusCode(STATUS_CODE_2);
 
         // select both
-        SeSelector seSelector = new SeSelector(null, atrFilter, aidSelector);
+        SeSelector seSelector =
+                new SeSelector.Builder().atrFilter(atrFilter).aidSelector(aidSelector).build();
 
         SelectionStatus status = r.openLogicalChannel(seSelector);
         Assert.assertEquals(true, status.hasMatched());
@@ -211,7 +212,7 @@ public class AbsLocalReaderSelectionTest extends CoreBaseTest {
     public void select_no_param() throws Exception {
         AbstractLocalReader r = getSpy(PLUGIN_NAME, READER_NAME);
 
-        SeSelector seSelector = new SeSelector(null, null, null);
+        SeSelector seSelector = new SeSelector.Builder().build();
 
         SelectionStatus status = r.openLogicalChannel(seSelector);
         Assert.assertEquals(true, status.hasMatched());
@@ -307,18 +308,18 @@ public class AbsLocalReaderSelectionTest extends CoreBaseTest {
 
     public static SeSelector getAidSelector() {
         SeSelector.AidSelector aidSelector =
-                new SeSelector.AidSelector(new SeSelector.AidSelector.IsoAid(AID));
+                new SeSelector.AidSelector.Builder().aidToSelect(AID).build();
         aidSelector.addSuccessfulStatusCode(STATUS_CODE_1);
         aidSelector.addSuccessfulStatusCode(STATUS_CODE_2);
 
-        return new SeSelector(null, null, aidSelector);
+        return new SeSelector.Builder().aidSelector(aidSelector).build();
     }
 
     public static SeSelector getAtrSelector() {
 
         SeSelector.AtrFilter atrFilter = new SeSelector.AtrFilter(ATR);
 
-        return new SeSelector(null, atrFilter, null);
+        return new SeSelector.Builder().atrFilter(atrFilter).build();
     }
 
 

--- a/java/component/keyple-core/src/test/java/org/eclipse/keyple/core/seproxy/plugin/local/AbsLocalReaderTransmitTest.java
+++ b/java/component/keyple-core/src/test/java/org/eclipse/keyple/core/seproxy/plugin/local/AbsLocalReaderTransmitTest.java
@@ -225,10 +225,10 @@ public class AbsLocalReaderTransmitTest extends CoreBaseTest {
             throws KeypleReaderException {
 
         SeSelector.AtrFilter atrFilter = new SeSelector.AtrFilter(ATR);
-        SeSelector selector = new SeSelector.Builder()
-                .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4).atrFilter(atrFilter).build();
+        SeSelector selector = SeSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                .atrFilter(atrFilter).build();
 
-        SeSelector failSelector = new SeSelector.Builder()
+        SeSelector failSelector = SeSelector.builder()
                 .seProtocol(SeCommonProtocols.PROTOCOL_MIFARE_UL).atrFilter(atrFilter).build();
 
         ApduRequest apduOK = new ApduRequest(APDU_SUCCESS, false);

--- a/java/component/keyple-core/src/test/java/org/eclipse/keyple/core/seproxy/plugin/local/AbsLocalReaderTransmitTest.java
+++ b/java/component/keyple-core/src/test/java/org/eclipse/keyple/core/seproxy/plugin/local/AbsLocalReaderTransmitTest.java
@@ -225,11 +225,11 @@ public class AbsLocalReaderTransmitTest extends CoreBaseTest {
             throws KeypleReaderException {
 
         SeSelector.AtrFilter atrFilter = new SeSelector.AtrFilter(ATR);
-        SeSelector selector =
-                new SeSelector(SeCommonProtocols.PROTOCOL_ISO14443_4, atrFilter, null);
+        SeSelector selector = new SeSelector.Builder()
+                .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4).atrFilter(atrFilter).build();
 
-        SeSelector failSelector =
-                new SeSelector(SeCommonProtocols.PROTOCOL_MIFARE_UL, atrFilter, null);
+        SeSelector failSelector = new SeSelector.Builder()
+                .seProtocol(SeCommonProtocols.PROTOCOL_MIFARE_UL).atrFilter(atrFilter).build();
 
         ApduRequest apduOK = new ApduRequest(APDU_SUCCESS, false);
         ApduRequest apduKO = new ApduRequest(APDU_IOEXC, false);

--- a/java/component/keyple-plugin/remotese/src/test/java/org/eclipse/keyple/plugin/remotese/integration/VirtualReaderEventTest.java
+++ b/java/component/keyple-plugin/remotese/src/test/java/org/eclipse/keyple/plugin/remotese/integration/VirtualReaderEventTest.java
@@ -246,8 +246,10 @@ public class VirtualReaderEventTest extends VirtualReaderBaseTest {
         SeSelection seSelection = new SeSelection();
 
         GenericSeSelectionRequest genericSeSelectionRequest = new GenericSeSelectionRequest(
-                new SeSelector(SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                        new SeSelector.AidSelector(new SeSelector.AidSelector.IsoAid(poAid))));
+                new SeSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                        .aidSelector(
+                                new SeSelector.AidSelector.Builder().aidToSelect(poAid).build())
+                        .build());
 
         seSelection.prepareSelection(genericSeSelectionRequest);
 
@@ -296,8 +298,10 @@ public class VirtualReaderEventTest extends VirtualReaderBaseTest {
         SeSelection seSelection = new SeSelection();
 
         GenericSeSelectionRequest genericSeSelectionRequest = new GenericSeSelectionRequest(
-                new SeSelector(SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                        new SeSelector.AidSelector(new SeSelector.AidSelector.IsoAid(poAid))));
+                new SeSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                        .aidSelector(
+                                new SeSelector.AidSelector.Builder().aidToSelect(poAid).build())
+                        .build());
 
         seSelection.prepareSelection(genericSeSelectionRequest);
 
@@ -357,8 +361,10 @@ public class VirtualReaderEventTest extends VirtualReaderBaseTest {
         SeSelection seSelection = new SeSelection();
 
         GenericSeSelectionRequest genericSeSelectionRequest = new GenericSeSelectionRequest(
-                new SeSelector(SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                        new SeSelector.AidSelector(new SeSelector.AidSelector.IsoAid(poAid))));
+                new SeSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                        .aidSelector(
+                                new SeSelector.AidSelector.Builder().aidToSelect(poAid).build())
+                        .build());
 
         seSelection.prepareSelection(genericSeSelectionRequest);
 
@@ -392,9 +398,9 @@ public class VirtualReaderEventTest extends VirtualReaderBaseTest {
         logger.info("Prepare SE Selection");
         SeSelection seSelection =
                 new SeSelection(MultiSeRequestProcessing.FIRST_MATCH, ChannelControl.KEEP_OPEN);
-        GenericSeSelectionRequest genericSeSelectionRequest =
-                new GenericSeSelectionRequest(new SeSelector(SeCommonProtocols.PROTOCOL_ISO14443_4,
-                        new SeSelector.AtrFilter("3B.*"), null));
+        GenericSeSelectionRequest genericSeSelectionRequest = new GenericSeSelectionRequest(
+                new SeSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                        .atrFilter(new SeSelector.AtrFilter("3B.*")).build());
 
         /* Prepare selector, ignore AbstractMatchingSe here */
         seSelection.prepareSelection(genericSeSelectionRequest);
@@ -433,8 +439,8 @@ public class VirtualReaderEventTest extends VirtualReaderBaseTest {
                 SeSelection seSelection = new SeSelection(MultiSeRequestProcessing.FIRST_MATCH,
                         ChannelControl.KEEP_OPEN);
                 GenericSeSelectionRequest genericSeSelectionRequest = new GenericSeSelectionRequest(
-                        new SeSelector(SeCommonProtocols.PROTOCOL_ISO14443_4,
-                                new SeSelector.AtrFilter("3B.*"), null));
+                        new SeSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                                .atrFilter(new SeSelector.AtrFilter("3B.*")).build());
 
                 /* Prepare selector, ignore AbstractMatchingSe here */
                 seSelection.prepareSelection(genericSeSelectionRequest);

--- a/java/component/keyple-plugin/remotese/src/test/java/org/eclipse/keyple/plugin/remotese/integration/VirtualReaderEventTest.java
+++ b/java/component/keyple-plugin/remotese/src/test/java/org/eclipse/keyple/plugin/remotese/integration/VirtualReaderEventTest.java
@@ -246,9 +246,8 @@ public class VirtualReaderEventTest extends VirtualReaderBaseTest {
         SeSelection seSelection = new SeSelection();
 
         GenericSeSelectionRequest genericSeSelectionRequest = new GenericSeSelectionRequest(
-                new SeSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                        .aidSelector(
-                                new SeSelector.AidSelector.Builder().aidToSelect(poAid).build())
+                SeSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                        .aidSelector(SeSelector.AidSelector.builder().aidToSelect(poAid).build())
                         .build());
 
         seSelection.prepareSelection(genericSeSelectionRequest);
@@ -298,9 +297,8 @@ public class VirtualReaderEventTest extends VirtualReaderBaseTest {
         SeSelection seSelection = new SeSelection();
 
         GenericSeSelectionRequest genericSeSelectionRequest = new GenericSeSelectionRequest(
-                new SeSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                        .aidSelector(
-                                new SeSelector.AidSelector.Builder().aidToSelect(poAid).build())
+                SeSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                        .aidSelector(SeSelector.AidSelector.builder().aidToSelect(poAid).build())
                         .build());
 
         seSelection.prepareSelection(genericSeSelectionRequest);
@@ -361,9 +359,8 @@ public class VirtualReaderEventTest extends VirtualReaderBaseTest {
         SeSelection seSelection = new SeSelection();
 
         GenericSeSelectionRequest genericSeSelectionRequest = new GenericSeSelectionRequest(
-                new SeSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                        .aidSelector(
-                                new SeSelector.AidSelector.Builder().aidToSelect(poAid).build())
+                SeSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                        .aidSelector(SeSelector.AidSelector.builder().aidToSelect(poAid).build())
                         .build());
 
         seSelection.prepareSelection(genericSeSelectionRequest);
@@ -399,7 +396,7 @@ public class VirtualReaderEventTest extends VirtualReaderBaseTest {
         SeSelection seSelection =
                 new SeSelection(MultiSeRequestProcessing.FIRST_MATCH, ChannelControl.KEEP_OPEN);
         GenericSeSelectionRequest genericSeSelectionRequest = new GenericSeSelectionRequest(
-                new SeSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                SeSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
                         .atrFilter(new SeSelector.AtrFilter("3B.*")).build());
 
         /* Prepare selector, ignore AbstractMatchingSe here */
@@ -439,7 +436,7 @@ public class VirtualReaderEventTest extends VirtualReaderBaseTest {
                 SeSelection seSelection = new SeSelection(MultiSeRequestProcessing.FIRST_MATCH,
                         ChannelControl.KEEP_OPEN);
                 GenericSeSelectionRequest genericSeSelectionRequest = new GenericSeSelectionRequest(
-                        new SeSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                        SeSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
                                 .atrFilter(new SeSelector.AtrFilter("3B.*")).build());
 
                 /* Prepare selector, ignore AbstractMatchingSe here */

--- a/java/component/keyple-plugin/remotese/src/test/java/org/eclipse/keyple/plugin/remotese/rm/json/SampleFactory.java
+++ b/java/component/keyple-plugin/remotese/src/test/java/org/eclipse/keyple/plugin/remotese/rm/json/SampleFactory.java
@@ -50,8 +50,14 @@ public class SampleFactory {
         List<ApduRequest> poApduRequests;
         poApduRequests = Arrays.asList(new ApduRequest(ByteArrayUtil.fromHex("9000"), true));
 
-        SeSelector seSelector = new SeSelector(SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                new SeSelector.AidSelector(new SeSelector.AidSelector.IsoAid(poAid)));
+        SeSelector.AidSelector aidSelector = new SeSelector.AidSelector.builder()//
+                .aidToSelect(poAid)//
+                .build();
+
+        SeSelector seSelector = new SeSelector.builder() //
+                .aidSelector(aidSelector) //
+                .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)//
+                .build();
 
         SeRequest seRequest = new SeRequest(seSelector, poApduRequests);
 
@@ -86,8 +92,14 @@ public class SampleFactory {
         List<ApduRequest> poApduRequests;
         poApduRequests = Arrays.asList(new ApduRequest(ByteArrayUtil.fromHex("9000"), true));
 
-        SeSelector seSelector = new SeSelector(SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                new SeSelector.AidSelector(new SeSelector.AidSelector.IsoAid(poAid)));
+        SeSelector.AidSelector aidSelector = new SeSelector.AidSelector.builder()//
+                .aidToSelect(poAid)//
+                .build();
+
+        SeSelector seSelector = new SeSelector.builder() //
+                .aidSelector(aidSelector) //
+                .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)//
+                .build();
 
         SeRequest seRequest = new SeRequest(seSelector, poApduRequests);
         return seRequest;
@@ -112,15 +124,25 @@ public class SampleFactory {
 
         poApduRequests = Arrays.asList(new ApduRequest(ByteArrayUtil.fromHex("9000"), true));
 
-        SeSelector aidSelector = new SeSelector(SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                new SeSelector.AidSelector(new SeSelector.AidSelector.IsoAid(poAid)));
+        SeSelector.AidSelector aidSelector = new SeSelector.AidSelector.builder()//
+                .aidToSelect(poAid)//
+                .build();
 
-        SeSelector atrSelector = new SeSelector(SeCommonProtocols.PROTOCOL_ISO7816_3,
-                new SeSelector.AtrFilter("/regex/"), null);
+        SeSelector aidSeSelector = new SeSelector.builder() //
+                .aidSelector(aidSelector) //
+                .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)//
+                .build();
 
-        SeRequest seRequest = new SeRequest(aidSelector, poApduRequests);
+        SeSelector.AtrFilter atrFilter = new SeSelector.AtrFilter("/regex/");
 
-        SeRequest seRequest2 = new SeRequest(atrSelector, poApduRequests);
+        SeSelector seAtrSelector = new SeSelector.builder() //
+                .atrFilter(atrFilter) //
+                .seProtocol(SeCommonProtocols.PROTOCOL_ISO7816_3)//
+                .build();
+
+        SeRequest seRequest = new SeRequest(aidSeSelector, poApduRequests);
+
+        SeRequest seRequest2 = new SeRequest(seAtrSelector, poApduRequests);
 
         List<SeRequest> seRequests = new ArrayList<SeRequest>();
         seRequests.add(seRequest);

--- a/java/component/keyple-plugin/remotese/src/test/java/org/eclipse/keyple/plugin/remotese/rm/json/SampleFactory.java
+++ b/java/component/keyple-plugin/remotese/src/test/java/org/eclipse/keyple/plugin/remotese/rm/json/SampleFactory.java
@@ -50,11 +50,11 @@ public class SampleFactory {
         List<ApduRequest> poApduRequests;
         poApduRequests = Arrays.asList(new ApduRequest(ByteArrayUtil.fromHex("9000"), true));
 
-        SeSelector.AidSelector aidSelector = new SeSelector.AidSelector.builder()//
+        SeSelector.AidSelector aidSelector = SeSelector.AidSelector.builder()//
                 .aidToSelect(poAid)//
                 .build();
 
-        SeSelector seSelector = new SeSelector.builder() //
+        SeSelector seSelector = SeSelector.builder() //
                 .aidSelector(aidSelector) //
                 .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)//
                 .build();
@@ -92,11 +92,11 @@ public class SampleFactory {
         List<ApduRequest> poApduRequests;
         poApduRequests = Arrays.asList(new ApduRequest(ByteArrayUtil.fromHex("9000"), true));
 
-        SeSelector.AidSelector aidSelector = new SeSelector.AidSelector.builder()//
+        SeSelector.AidSelector aidSelector = SeSelector.AidSelector.builder()//
                 .aidToSelect(poAid)//
                 .build();
 
-        SeSelector seSelector = new SeSelector.builder() //
+        SeSelector seSelector = SeSelector.builder() //
                 .aidSelector(aidSelector) //
                 .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)//
                 .build();
@@ -124,18 +124,18 @@ public class SampleFactory {
 
         poApduRequests = Arrays.asList(new ApduRequest(ByteArrayUtil.fromHex("9000"), true));
 
-        SeSelector.AidSelector aidSelector = new SeSelector.AidSelector.builder()//
+        SeSelector.AidSelector aidSelector = SeSelector.AidSelector.builder()//
                 .aidToSelect(poAid)//
                 .build();
 
-        SeSelector aidSeSelector = new SeSelector.builder() //
+        SeSelector aidSeSelector = SeSelector.builder() //
                 .aidSelector(aidSelector) //
                 .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)//
                 .build();
 
         SeSelector.AtrFilter atrFilter = new SeSelector.AtrFilter("/regex/");
 
-        SeSelector seAtrSelector = new SeSelector.builder() //
+        SeSelector seAtrSelector = SeSelector.builder() //
                 .atrFilter(atrFilter) //
                 .seProtocol(SeCommonProtocols.PROTOCOL_ISO7816_3)//
                 .build();

--- a/java/component/keyple-plugin/stub/src/test/java/org/eclipse/keyple/plugin/stub/StubReaderTest.java
+++ b/java/component/keyple-plugin/stub/src/test/java/org/eclipse/keyple/plugin/stub/StubReaderTest.java
@@ -466,10 +466,10 @@ public class StubReaderTest extends BaseStubTest {
 
         SeSelection seSelection = new SeSelection();
 
-        PoSelectionRequest poSelectionRequest =
-                new PoSelectionRequest(new PoSelector(SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                        new PoSelector.AidSelector(new SeSelector.AidSelector.IsoAid(poAid)),
-                        PoSelector.InvalidatedPo.REJECT));
+        PoSelectionRequest poSelectionRequest = new PoSelectionRequest(new PoSelector.Builder()
+                .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                .aidSelector(new SeSelector.AidSelector.Builder().aidToSelect(poAid).build())
+                .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
 
         seSelection.prepareSelection(poSelectionRequest);
 
@@ -517,10 +517,10 @@ public class StubReaderTest extends BaseStubTest {
 
         SeSelection seSelection = new SeSelection();
 
-        PoSelectionRequest poSelectionRequest =
-                new PoSelectionRequest(new PoSelector(SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                        new PoSelector.AidSelector(new PoSelector.AidSelector.IsoAid(poAid)),
-                        PoSelector.InvalidatedPo.REJECT));
+        PoSelectionRequest poSelectionRequest = new PoSelectionRequest(new PoSelector.Builder()
+                .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                .aidSelector(new SeSelector.AidSelector.Builder().aidToSelect(poAid).build())
+                .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
 
         seSelection.prepareSelection(poSelectionRequest);
 
@@ -580,10 +580,10 @@ public class StubReaderTest extends BaseStubTest {
 
         SeSelection seSelection = new SeSelection();
 
-        PoSelectionRequest poSelectionRequest =
-                new PoSelectionRequest(new PoSelector(SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                        new PoSelector.AidSelector(new PoSelector.AidSelector.IsoAid(poAid)),
-                        PoSelector.InvalidatedPo.REJECT));
+        PoSelectionRequest poSelectionRequest = new PoSelectionRequest(new PoSelector.Builder()
+                .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                .aidSelector(new SeSelector.AidSelector.Builder().aidToSelect(poAid).build())
+                .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
 
         seSelection.prepareSelection(poSelectionRequest);
 
@@ -621,10 +621,10 @@ public class StubReaderTest extends BaseStubTest {
                 SeSelection seSelection = new SeSelection(MultiSeRequestProcessing.FIRST_MATCH,
                         ChannelControl.KEEP_OPEN);
 
-                PoSelectionRequest poSelectionRequest =
-                        new PoSelectionRequest(new PoSelector(SeCommonProtocols.PROTOCOL_B_PRIME,
-                                new PoSelector.AtrFilter("3B.*"), null,
-                                PoSelector.InvalidatedPo.REJECT));
+                PoSelectionRequest poSelectionRequest = new PoSelectionRequest(
+                        new PoSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_B_PRIME)
+                                .atrFilter(new PoSelector.AtrFilter("3B.*"))
+                                .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
 
                 /* Prepare selector, ignore AbstractMatchingSe here */
                 seSelection.prepareSelection(poSelectionRequest);
@@ -697,10 +697,10 @@ public class StubReaderTest extends BaseStubTest {
 
         SeSelection seSelection = new SeSelection();
 
-        PoSelectionRequest poSelectionRequest =
-                new PoSelectionRequest(new PoSelector(SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                        new PoSelector.AidSelector(new PoSelector.AidSelector.IsoAid(poAid)),
-                        PoSelector.InvalidatedPo.REJECT));
+        PoSelectionRequest poSelectionRequest = new PoSelectionRequest(new PoSelector.Builder()
+                .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                .aidSelector(new SeSelector.AidSelector.Builder().aidToSelect(poAid).build())
+                .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
 
         seSelection.prepareSelection(poSelectionRequest);
 
@@ -1234,10 +1234,6 @@ public class StubReaderTest extends BaseStubTest {
                 break;
         }
 
-        SeSelector selector = new SeSelector(SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                new SeSelector.AidSelector(
-                        new SeSelector.AidSelector.IsoAid(ByteArrayUtil.fromHex(poAid))));
-
         return new SeRequest(poApduRequests);
     }
 
@@ -1425,9 +1421,9 @@ public class StubReaderTest extends BaseStubTest {
         SeSelection seSelection = new SeSelection();
         // SeSelection seSelection = new SeSelection(MultiSeRequestProcessing.PROCESS_ALL,
         // ChannelControl.CLOSE_AFTER);
-        GenericSeSelectionRequest genericSeSelectionRequest =
-                new GenericSeSelectionRequest(new SeSelector(SeCommonProtocols.PROTOCOL_ISO14443_4,
-                        new SeSelector.AtrFilter("3B.*"), null));
+        GenericSeSelectionRequest genericSeSelectionRequest = new GenericSeSelectionRequest(
+                new SeSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                        .atrFilter(new SeSelector.AtrFilter("3B.*")).build());
 
         /* Prepare selector, ignore AbstractMatchingSe here */
         seSelection.prepareSelection(genericSeSelectionRequest);

--- a/java/component/keyple-plugin/stub/src/test/java/org/eclipse/keyple/plugin/stub/StubReaderTest.java
+++ b/java/component/keyple-plugin/stub/src/test/java/org/eclipse/keyple/plugin/stub/StubReaderTest.java
@@ -466,10 +466,10 @@ public class StubReaderTest extends BaseStubTest {
 
         SeSelection seSelection = new SeSelection();
 
-        PoSelectionRequest poSelectionRequest = new PoSelectionRequest(new PoSelector.Builder()
-                .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                .aidSelector(new SeSelector.AidSelector.Builder().aidToSelect(poAid).build())
-                .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
+        PoSelectionRequest poSelectionRequest = new PoSelectionRequest(
+                PoSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                        .aidSelector(SeSelector.AidSelector.builder().aidToSelect(poAid).build())
+                        .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
 
         seSelection.prepareSelection(poSelectionRequest);
 
@@ -517,10 +517,10 @@ public class StubReaderTest extends BaseStubTest {
 
         SeSelection seSelection = new SeSelection();
 
-        PoSelectionRequest poSelectionRequest = new PoSelectionRequest(new PoSelector.Builder()
-                .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                .aidSelector(new SeSelector.AidSelector.Builder().aidToSelect(poAid).build())
-                .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
+        PoSelectionRequest poSelectionRequest = new PoSelectionRequest(
+                PoSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                        .aidSelector(SeSelector.AidSelector.builder().aidToSelect(poAid).build())
+                        .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
 
         seSelection.prepareSelection(poSelectionRequest);
 
@@ -580,10 +580,10 @@ public class StubReaderTest extends BaseStubTest {
 
         SeSelection seSelection = new SeSelection();
 
-        PoSelectionRequest poSelectionRequest = new PoSelectionRequest(new PoSelector.Builder()
-                .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                .aidSelector(new SeSelector.AidSelector.Builder().aidToSelect(poAid).build())
-                .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
+        PoSelectionRequest poSelectionRequest = new PoSelectionRequest(
+                PoSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                        .aidSelector(SeSelector.AidSelector.builder().aidToSelect(poAid).build())
+                        .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
 
         seSelection.prepareSelection(poSelectionRequest);
 
@@ -622,7 +622,7 @@ public class StubReaderTest extends BaseStubTest {
                         ChannelControl.KEEP_OPEN);
 
                 PoSelectionRequest poSelectionRequest = new PoSelectionRequest(
-                        new PoSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_B_PRIME)
+                        PoSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_B_PRIME)
                                 .atrFilter(new PoSelector.AtrFilter("3B.*"))
                                 .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
 
@@ -697,10 +697,10 @@ public class StubReaderTest extends BaseStubTest {
 
         SeSelection seSelection = new SeSelection();
 
-        PoSelectionRequest poSelectionRequest = new PoSelectionRequest(new PoSelector.Builder()
-                .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                .aidSelector(new SeSelector.AidSelector.Builder().aidToSelect(poAid).build())
-                .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
+        PoSelectionRequest poSelectionRequest = new PoSelectionRequest(
+                PoSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                        .aidSelector(SeSelector.AidSelector.builder().aidToSelect(poAid).build())
+                        .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
 
         seSelection.prepareSelection(poSelectionRequest);
 
@@ -1422,7 +1422,7 @@ public class StubReaderTest extends BaseStubTest {
         // SeSelection seSelection = new SeSelection(MultiSeRequestProcessing.PROCESS_ALL,
         // ChannelControl.CLOSE_AFTER);
         GenericSeSelectionRequest genericSeSelectionRequest = new GenericSeSelectionRequest(
-                new SeSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                SeSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
                         .atrFilter(new SeSelector.AtrFilter("3B.*")).build());
 
         /* Prepare selector, ignore AbstractMatchingSe here */

--- a/java/example/calypso/android/nfc/src/main/kotlin/org/eclipse/keyple/example/activity/CalypsoExamplesActivity.kt
+++ b/java/example/calypso/android/nfc/src/main/kotlin/org/eclipse/keyple/example/activity/CalypsoExamplesActivity.kt
@@ -166,11 +166,11 @@ class CalypsoExamplesActivity : AbstractExampleActivity() {
             seSelection = SeSelection(MultiSeRequestProcessing.FIRST_MATCH, ChannelControl.KEEP_OPEN)
 
             /* AID based selection (1st selection, later indexed 0) */
-            val selectionRequest1st = PoSelectionRequest(PoSelector(
-                    SeCommonProtocols.PROTOCOL_ISO14443_4, null, SeSelector.AidSelector(
-                    SeSelector.AidSelector.IsoAid(seAidPrefix),
-                    SeSelector.AidSelector.FileOccurrence.FIRST,
-                    SeSelector.AidSelector.FileControlInformation.FCI), PoSelector.InvalidatedPo.REJECT))
+            val selectionRequest1st = PoSelectionRequest(PoSelector.builder().seProtocol(
+                    SeCommonProtocols.PROTOCOL_ISO14443_4).aidSelector(SeSelector.AidSelector.builder().aidToSelect(
+                    seAidPrefix).fileOccurrence(
+                    SeSelector.AidSelector.FileOccurrence.FIRST).fileControlInformation(
+                    SeSelector.AidSelector.FileControlInformation.FCI).build()).invalidatedPo(PoSelector.InvalidatedPo.REJECT).build())
 
             seSelection.prepareSelection(selectionRequest1st)
 
@@ -184,11 +184,10 @@ class CalypsoExamplesActivity : AbstractExampleActivity() {
               */
             seSelection = SeSelection(MultiSeRequestProcessing.FIRST_MATCH, ChannelControl.CLOSE_AFTER)
 
-            val selectionRequest2nd = PoSelectionRequest(PoSelector(
-                    SeCommonProtocols.PROTOCOL_ISO14443_4, null, SeSelector.AidSelector(
-                    SeSelector.AidSelector.IsoAid(seAidPrefix),
-                    SeSelector.AidSelector.FileOccurrence.NEXT,
-                    SeSelector.AidSelector.FileControlInformation.FCI), PoSelector.InvalidatedPo.REJECT))
+            val selectionRequest2nd = PoSelectionRequest(PoSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4).aidSelector(
+                    SeSelector.AidSelector.builder().aidToSelect(seAidPrefix).fileOccurrence(
+                    SeSelector.AidSelector.FileOccurrence.NEXT).fileControlInformation(
+                    SeSelector.AidSelector.FileControlInformation.FCI).build()).invalidatedPo(PoSelector.InvalidatedPo.REJECT).build())
 
             seSelection.prepareSelection(selectionRequest2nd)
 
@@ -232,29 +231,29 @@ class CalypsoExamplesActivity : AbstractExampleActivity() {
 
         if (reader.isSePresent) {
             /* AID based selection (1st selection, later indexed 0) */
-            val selectionRequest1st = PoSelectionRequest(PoSelector(
-                    SeCommonProtocols.PROTOCOL_ISO14443_4, null, SeSelector.AidSelector(
-                    SeSelector.AidSelector.IsoAid(seAidPrefix),
-                    SeSelector.AidSelector.FileOccurrence.FIRST,
-                    SeSelector.AidSelector.FileControlInformation.FCI), PoSelector.InvalidatedPo.REJECT))
+            val selectionRequest1st = PoSelectionRequest(PoSelector.builder().seProtocol(
+                    SeCommonProtocols.PROTOCOL_ISO14443_4).aidSelector(
+                    SeSelector.AidSelector.builder().aidToSelect(seAidPrefix).fileOccurrence(
+                    SeSelector.AidSelector.FileOccurrence.FIRST).fileControlInformation(
+                    SeSelector.AidSelector.FileControlInformation.FCI).build()).invalidatedPo(PoSelector.InvalidatedPo.REJECT).build())
 
             seSelection.prepareSelection(selectionRequest1st)
 
             /* next selection (2nd selection, later indexed 1) */
-            val selectionRequest2nd = PoSelectionRequest(PoSelector(
-                    SeCommonProtocols.PROTOCOL_ISO14443_4, null, SeSelector.AidSelector(
-                    SeSelector.AidSelector.IsoAid(seAidPrefix),
-                    SeSelector.AidSelector.FileOccurrence.NEXT,
-                    SeSelector.AidSelector.FileControlInformation.FCI), PoSelector.InvalidatedPo.REJECT))
+            val selectionRequest2nd = PoSelectionRequest(PoSelector.builder().seProtocol(
+                    SeCommonProtocols.PROTOCOL_ISO14443_4).aidSelector(
+                    SeSelector.AidSelector.builder().aidToSelect(seAidPrefix).fileOccurrence(
+                            SeSelector.AidSelector.FileOccurrence.NEXT).fileControlInformation(
+                            SeSelector.AidSelector.FileControlInformation.FCI).build()).invalidatedPo(PoSelector.InvalidatedPo.REJECT).build())
 
             seSelection.prepareSelection(selectionRequest2nd)
 
             /* next selection (3rd selection, later indexed 2) */
-            val selectionRequest3rd = PoSelectionRequest(PoSelector(
-                    SeCommonProtocols.PROTOCOL_ISO14443_4, null, SeSelector.AidSelector(
-                    SeSelector.AidSelector.IsoAid(seAidPrefix),
-                    SeSelector.AidSelector.FileOccurrence.NEXT,
-                    SeSelector.AidSelector.FileControlInformation.FCI), PoSelector.InvalidatedPo.REJECT))
+            val selectionRequest3rd = PoSelectionRequest(PoSelector.builder().seProtocol(
+                    SeCommonProtocols.PROTOCOL_ISO14443_4).aidSelector(
+                    SeSelector.AidSelector.builder().aidToSelect(seAidPrefix).fileOccurrence(
+                            SeSelector.AidSelector.FileOccurrence.NEXT).fileControlInformation(
+                            SeSelector.AidSelector.FileControlInformation.FCI).build()).invalidatedPo(PoSelector.InvalidatedPo.REJECT).build())
 
             seSelection.prepareSelection(selectionRequest3rd)
 
@@ -311,10 +310,9 @@ class CalypsoExamplesActivity : AbstractExampleActivity() {
          * Generic selection: configures a SeSelector with all the desired attributes to make the
          * selection
          */
-        val selectionRequest = PoSelectionRequest(PoSelector(
-                SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                SeSelector.AidSelector(
-                        SeSelector.AidSelector.IsoAid(aid)), PoSelector.InvalidatedPo.REJECT))
+        val selectionRequest = PoSelectionRequest(PoSelector.builder().seProtocol(
+                SeCommonProtocols.PROTOCOL_ISO14443_4).aidSelector(
+                        SeSelector.AidSelector.builder().aidToSelect(aid).build()).invalidatedPo(PoSelector.InvalidatedPo.REJECT).build())
 
         /*
         * Add the selection case to the current selection (we could have added other cases here)
@@ -394,10 +392,9 @@ class CalypsoExamplesActivity : AbstractExampleActivity() {
             /**
              * configure Protocol
              */
-            val selectionRequest = PoSelectionRequest(PoSelector(
-                    SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                    SeSelector.AidSelector(
-                            SeSelector.AidSelector.IsoAid(aid)), PoSelector.InvalidatedPo.REJECT))
+            val selectionRequest = PoSelectionRequest(PoSelector.builder().seProtocol(
+                    SeCommonProtocols.PROTOCOL_ISO14443_4).aidSelector(
+                            SeSelector.AidSelector.builder().aidToSelect(aid).build()).invalidatedPo(PoSelector.InvalidatedPo.REJECT).build())
 
             /**
              * Prepare Selection
@@ -456,11 +453,10 @@ class CalypsoExamplesActivity : AbstractExampleActivity() {
              * Calypso selection: configures a PoSelector with all the desired attributes to make
              * the selection and read additional information afterwards
              */
-        val poSelectionRequest = PoSelectionRequest(PoSelector(
-                SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                SeSelector.AidSelector(
-                        SeSelector.AidSelector.IsoAid(CalypsoClassicInfo.AID)),
-                PoSelector.InvalidatedPo.REJECT))
+        val poSelectionRequest = PoSelectionRequest(PoSelector.builder().seProtocol(
+                SeCommonProtocols.PROTOCOL_ISO14443_4).aidSelector(
+                SeSelector.AidSelector.builder().aidToSelect(CalypsoClassicInfo.AID).build()).invalidatedPo(
+                PoSelector.InvalidatedPo.REJECT).build())
 
         /*
              * Prepare the reading order and keep the associated parser for later use once the

--- a/java/example/calypso/android/nfc/src/main/kotlin/org/eclipse/keyple/example/activity/CalypsoExamplesActivity.kt
+++ b/java/example/calypso/android/nfc/src/main/kotlin/org/eclipse/keyple/example/activity/CalypsoExamplesActivity.kt
@@ -25,13 +25,14 @@ import org.eclipse.keyple.calypso.transaction.CalypsoPo
 import org.eclipse.keyple.calypso.transaction.PoResource
 import org.eclipse.keyple.calypso.transaction.PoSelectionRequest
 import org.eclipse.keyple.calypso.transaction.PoSelector
+import org.eclipse.keyple.calypso.transaction.PoSelector.InvalidatedPo
 import org.eclipse.keyple.calypso.transaction.PoTransaction
 import org.eclipse.keyple.core.selection.SeSelection
 import org.eclipse.keyple.core.seproxy.ChannelControl
 import org.eclipse.keyple.core.seproxy.MultiSeRequestProcessing
 import org.eclipse.keyple.core.seproxy.SeProxyService
 import org.eclipse.keyple.core.seproxy.SeReader
-import org.eclipse.keyple.core.seproxy.SeSelector
+import org.eclipse.keyple.core.seproxy.SeSelector.AidSelector
 import org.eclipse.keyple.core.seproxy.event.AbstractDefaultSelectionsResponse
 import org.eclipse.keyple.core.seproxy.event.ObservableReader
 import org.eclipse.keyple.core.seproxy.event.ReaderEvent
@@ -167,10 +168,10 @@ class CalypsoExamplesActivity : AbstractExampleActivity() {
 
             /* AID based selection (1st selection, later indexed 0) */
             val selectionRequest1st = PoSelectionRequest(PoSelector.builder().seProtocol(
-                    SeCommonProtocols.PROTOCOL_ISO14443_4).aidSelector(SeSelector.AidSelector.builder().aidToSelect(
+                    SeCommonProtocols.PROTOCOL_ISO14443_4).aidSelector(AidSelector.builder().aidToSelect(
                     seAidPrefix).fileOccurrence(
-                    SeSelector.AidSelector.FileOccurrence.FIRST).fileControlInformation(
-                    SeSelector.AidSelector.FileControlInformation.FCI).build()).invalidatedPo(PoSelector.InvalidatedPo.REJECT).build())
+                    AidSelector.FileOccurrence.FIRST).fileControlInformation(
+                    AidSelector.FileControlInformation.FCI).build()).invalidatedPo(InvalidatedPo.REJECT).build())
 
             seSelection.prepareSelection(selectionRequest1st)
 
@@ -185,9 +186,9 @@ class CalypsoExamplesActivity : AbstractExampleActivity() {
             seSelection = SeSelection(MultiSeRequestProcessing.FIRST_MATCH, ChannelControl.CLOSE_AFTER)
 
             val selectionRequest2nd = PoSelectionRequest(PoSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4).aidSelector(
-                    SeSelector.AidSelector.builder().aidToSelect(seAidPrefix).fileOccurrence(
-                    SeSelector.AidSelector.FileOccurrence.NEXT).fileControlInformation(
-                    SeSelector.AidSelector.FileControlInformation.FCI).build()).invalidatedPo(PoSelector.InvalidatedPo.REJECT).build())
+                    AidSelector.builder().aidToSelect(seAidPrefix).fileOccurrence(
+                    AidSelector.FileOccurrence.NEXT).fileControlInformation(
+                    AidSelector.FileControlInformation.FCI).build()).invalidatedPo(InvalidatedPo.REJECT).build())
 
             seSelection.prepareSelection(selectionRequest2nd)
 
@@ -233,27 +234,27 @@ class CalypsoExamplesActivity : AbstractExampleActivity() {
             /* AID based selection (1st selection, later indexed 0) */
             val selectionRequest1st = PoSelectionRequest(PoSelector.builder().seProtocol(
                     SeCommonProtocols.PROTOCOL_ISO14443_4).aidSelector(
-                    SeSelector.AidSelector.builder().aidToSelect(seAidPrefix).fileOccurrence(
-                    SeSelector.AidSelector.FileOccurrence.FIRST).fileControlInformation(
-                    SeSelector.AidSelector.FileControlInformation.FCI).build()).invalidatedPo(PoSelector.InvalidatedPo.REJECT).build())
+                    AidSelector.builder().aidToSelect(seAidPrefix).fileOccurrence(
+                    AidSelector.FileOccurrence.FIRST).fileControlInformation(
+                    AidSelector.FileControlInformation.FCI).build()).invalidatedPo(InvalidatedPo.REJECT).build())
 
             seSelection.prepareSelection(selectionRequest1st)
 
             /* next selection (2nd selection, later indexed 1) */
             val selectionRequest2nd = PoSelectionRequest(PoSelector.builder().seProtocol(
                     SeCommonProtocols.PROTOCOL_ISO14443_4).aidSelector(
-                    SeSelector.AidSelector.builder().aidToSelect(seAidPrefix).fileOccurrence(
-                            SeSelector.AidSelector.FileOccurrence.NEXT).fileControlInformation(
-                            SeSelector.AidSelector.FileControlInformation.FCI).build()).invalidatedPo(PoSelector.InvalidatedPo.REJECT).build())
+                    AidSelector.builder().aidToSelect(seAidPrefix).fileOccurrence(
+                            AidSelector.FileOccurrence.NEXT).fileControlInformation(
+                            AidSelector.FileControlInformation.FCI).build()).invalidatedPo(InvalidatedPo.REJECT).build())
 
             seSelection.prepareSelection(selectionRequest2nd)
 
             /* next selection (3rd selection, later indexed 2) */
             val selectionRequest3rd = PoSelectionRequest(PoSelector.builder().seProtocol(
                     SeCommonProtocols.PROTOCOL_ISO14443_4).aidSelector(
-                    SeSelector.AidSelector.builder().aidToSelect(seAidPrefix).fileOccurrence(
-                            SeSelector.AidSelector.FileOccurrence.NEXT).fileControlInformation(
-                            SeSelector.AidSelector.FileControlInformation.FCI).build()).invalidatedPo(PoSelector.InvalidatedPo.REJECT).build())
+                    AidSelector.builder().aidToSelect(seAidPrefix).fileOccurrence(
+                            AidSelector.FileOccurrence.NEXT).fileControlInformation(
+                            AidSelector.FileControlInformation.FCI).build()).invalidatedPo(InvalidatedPo.REJECT).build())
 
             seSelection.prepareSelection(selectionRequest3rd)
 
@@ -312,7 +313,7 @@ class CalypsoExamplesActivity : AbstractExampleActivity() {
          */
         val selectionRequest = PoSelectionRequest(PoSelector.builder().seProtocol(
                 SeCommonProtocols.PROTOCOL_ISO14443_4).aidSelector(
-                        SeSelector.AidSelector.builder().aidToSelect(aid).build()).invalidatedPo(PoSelector.InvalidatedPo.REJECT).build())
+                        AidSelector.builder().aidToSelect(aid).build()).invalidatedPo(InvalidatedPo.REJECT).build())
 
         /*
         * Add the selection case to the current selection (we could have added other cases here)
@@ -394,7 +395,7 @@ class CalypsoExamplesActivity : AbstractExampleActivity() {
              */
             val selectionRequest = PoSelectionRequest(PoSelector.builder().seProtocol(
                     SeCommonProtocols.PROTOCOL_ISO14443_4).aidSelector(
-                            SeSelector.AidSelector.builder().aidToSelect(aid).build()).invalidatedPo(PoSelector.InvalidatedPo.REJECT).build())
+                            AidSelector.builder().aidToSelect(aid).build()).invalidatedPo(InvalidatedPo.REJECT).build())
 
             /**
              * Prepare Selection
@@ -455,8 +456,8 @@ class CalypsoExamplesActivity : AbstractExampleActivity() {
              */
         val poSelectionRequest = PoSelectionRequest(PoSelector.builder().seProtocol(
                 SeCommonProtocols.PROTOCOL_ISO14443_4).aidSelector(
-                SeSelector.AidSelector.builder().aidToSelect(CalypsoClassicInfo.AID).build()).invalidatedPo(
-                PoSelector.InvalidatedPo.REJECT).build())
+                AidSelector.builder().aidToSelect(CalypsoClassicInfo.AID).build()).invalidatedPo(
+                InvalidatedPo.REJECT).build())
 
         /*
              * Prepare the reading order and keep the associated parser for later use once the

--- a/java/example/calypso/android/nfc/src/main/kotlin/org/eclipse/keyple/example/activity/CoreExamplesActivity.kt
+++ b/java/example/calypso/android/nfc/src/main/kotlin/org/eclipse/keyple/example/activity/CoreExamplesActivity.kt
@@ -28,6 +28,7 @@ import org.eclipse.keyple.core.seproxy.MultiSeRequestProcessing
 import org.eclipse.keyple.core.seproxy.SeProxyService
 import org.eclipse.keyple.core.seproxy.SeReader
 import org.eclipse.keyple.core.seproxy.SeSelector
+import org.eclipse.keyple.core.seproxy.SeSelector.AidSelector
 import org.eclipse.keyple.core.seproxy.event.ObservableReader
 import org.eclipse.keyple.core.seproxy.event.ReaderEvent
 import org.eclipse.keyple.core.seproxy.exception.KeyplePluginNotFoundException
@@ -98,7 +99,7 @@ class CoreExamplesActivity : AbstractExampleActivity() {
                     GenericSeSelectionRequest(
                             SeSelector.builder()
                                     .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                                    .aidSelector(SeSelector.AidSelector.builder()
+                                    .aidSelector(AidSelector.builder()
                                             .aidToSelect(seAidPrefix)
                                             .fileOccurrence(SeSelector.AidSelector.FileOccurrence.FIRST)
                                             .fileControlInformation(SeSelector.AidSelector.FileControlInformation.FCI).build())
@@ -251,7 +252,7 @@ class CoreExamplesActivity : AbstractExampleActivity() {
          */
         val seSelector = GenericSeSelectionRequest(SeSelector.builder()
                 .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                .aidSelector(SeSelector.AidSelector.builder()
+                .aidSelector(AidSelector.builder()
                         .aidToSelect(aid).build())
                 .build())
 
@@ -343,7 +344,7 @@ class CoreExamplesActivity : AbstractExampleActivity() {
              */
             val genericSeSelectionRequest = GenericSeSelectionRequest(
                     SeSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4).aidSelector(
-                            SeSelector.AidSelector.builder().aidToSelect(aid).build()).build())
+                            AidSelector.builder().aidToSelect(aid).build()).build())
 
             /**
              * Prepare Selection

--- a/java/example/calypso/android/nfc/src/main/kotlin/org/eclipse/keyple/example/activity/CoreExamplesActivity.kt
+++ b/java/example/calypso/android/nfc/src/main/kotlin/org/eclipse/keyple/example/activity/CoreExamplesActivity.kt
@@ -96,11 +96,13 @@ class CoreExamplesActivity : AbstractExampleActivity() {
             /* AID based selection (1st selection, later indexed 0) */
             seSelection.prepareSelection(
                     GenericSeSelectionRequest(
-                            SeSelector(
-                                    SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                                    SeSelector.AidSelector(SeSelector.AidSelector.IsoAid(seAidPrefix),
-                                            SeSelector.AidSelector.FileOccurrence.FIRST,
-                                            SeSelector.AidSelector.FileControlInformation.FCI))))
+                            SeSelector.builder()
+                                    .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                                    .aidSelector(SeSelector.AidSelector.builder()
+                                            .aidToSelect(seAidPrefix)
+                                            .fileOccurrence(SeSelector.AidSelector.FileOccurrence.FIRST)
+                                            .fileControlInformation(SeSelector.AidSelector.FileControlInformation.FCI).build())
+                                    .build()))
 
             /* Do the selection and display the result */
             addActionEvent("FIRST MATCH Calypso PO selection for prefix: $seAidPrefix")
@@ -115,11 +117,13 @@ class CoreExamplesActivity : AbstractExampleActivity() {
             /* next selection (2nd selection, later indexed 1) */
             seSelection.prepareSelection(
                     GenericSeSelectionRequest(
-                            SeSelector(
-                                    SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                                    SeSelector.AidSelector(SeSelector.AidSelector.IsoAid(seAidPrefix),
-                                            SeSelector.AidSelector.FileOccurrence.NEXT,
-                                            SeSelector.AidSelector.FileControlInformation.FCI))))
+                            SeSelector.builder()
+                                    .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                                    .aidSelector(SeSelector.AidSelector.builder()
+                                            .aidToSelect(seAidPrefix)
+                                            .fileOccurrence(SeSelector.AidSelector.FileOccurrence.NEXT)
+                                            .fileControlInformation(SeSelector.AidSelector.FileControlInformation.FCI).build())
+                                    .build()))
 
             /* Do the selection and display the result */
             addActionEvent("NEXT MATCH Calypso PO selection for prefix: $seAidPrefix")
@@ -163,29 +167,35 @@ class CoreExamplesActivity : AbstractExampleActivity() {
             /* AID based selection (1st selection, later indexed 0) */
             seSelection.prepareSelection(
                     GenericSeSelectionRequest(
-                            SeSelector(
-                                    SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                                    SeSelector.AidSelector(SeSelector.AidSelector.IsoAid(seAidPrefix),
-                                            SeSelector.AidSelector.FileOccurrence.FIRST,
-                                            SeSelector.AidSelector.FileControlInformation.FCI))))
+                            SeSelector.builder()
+                                    .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                                    .aidSelector(SeSelector.AidSelector.builder()
+                                            .aidToSelect(seAidPrefix)
+                                            .fileOccurrence(SeSelector.AidSelector.FileOccurrence.FIRST)
+                                            .fileControlInformation(SeSelector.AidSelector.FileControlInformation.FCI).build())
+                                    .build()))
 
             /* next selection (2nd selection, later indexed 1) */
             seSelection.prepareSelection(
                     GenericSeSelectionRequest(
-                            SeSelector(
-                                    SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                                    SeSelector.AidSelector(SeSelector.AidSelector.IsoAid(seAidPrefix),
-                                            SeSelector.AidSelector.FileOccurrence.NEXT,
-                                            SeSelector.AidSelector.FileControlInformation.FCI))))
+                            SeSelector.builder()
+                                    .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                                    .aidSelector(SeSelector.AidSelector.builder()
+                                            .aidToSelect(seAidPrefix)
+                                            .fileOccurrence(SeSelector.AidSelector.FileOccurrence.NEXT)
+                                            .fileControlInformation(SeSelector.AidSelector.FileControlInformation.FCI).build())
+                                    .build()))
 
             /* next selection (3rd selection, later indexed 2) */
             seSelection.prepareSelection(
                     GenericSeSelectionRequest(
-                            SeSelector(
-                                    SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                                    SeSelector.AidSelector(SeSelector.AidSelector.IsoAid(seAidPrefix),
-                                            SeSelector.AidSelector.FileOccurrence.NEXT,
-                                            SeSelector.AidSelector.FileControlInformation.FCI))))
+                            SeSelector.builder()
+                                    .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                                    .aidSelector(SeSelector.AidSelector.builder()
+                                            .aidToSelect(seAidPrefix)
+                                            .fileOccurrence(SeSelector.AidSelector.FileOccurrence.NEXT)
+                                            .fileControlInformation(SeSelector.AidSelector.FileControlInformation.FCI).build())
+                                    .build()))
 
             addActionEvent("Calypso PO selection for prefix: $seAidPrefix")
 
@@ -239,10 +249,11 @@ class CoreExamplesActivity : AbstractExampleActivity() {
          * Generic selection: configures a SeSelector with all the desired attributes to make the
          * selection
          */
-        val seSelector = GenericSeSelectionRequest(SeSelector(
-                SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                SeSelector.AidSelector(
-                        SeSelector.AidSelector.IsoAid(ByteArrayUtil.fromHex(aid)))))
+        val seSelector = GenericSeSelectionRequest(SeSelector.builder()
+                .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                .aidSelector(SeSelector.AidSelector.builder()
+                        .aidToSelect(aid).build())
+                .build())
 
         /*
         * Add the selection case to the current selection (we could have added other cases here)
@@ -331,10 +342,8 @@ class CoreExamplesActivity : AbstractExampleActivity() {
              * the selection and read additional information afterwards
              */
             val genericSeSelectionRequest = GenericSeSelectionRequest(
-                    SeSelector(SeCommonProtocols.PROTOCOL_ISO14443_4,
-                            null,
-                            SeSelector.AidSelector(
-                                    SeSelector.AidSelector.IsoAid(ByteArrayUtil.fromHex(aid)))))
+                    SeSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4).aidSelector(
+                            SeSelector.AidSelector.builder().aidToSelect(aid).build()).build())
 
             /**
              * Prepare Selection

--- a/java/example/calypso/android/omapi/src/main/kotlin/org/eclipse/keyple/example/calypso/android/omapi/activity/CalypsoExamplesActivity.kt
+++ b/java/example/calypso/android/omapi/src/main/kotlin/org/eclipse/keyple/example/calypso/android/omapi/activity/CalypsoExamplesActivity.kt
@@ -60,10 +60,10 @@ class CalypsoExamplesActivity : ExamplesActivity() {
                      *
                      */
                     val poSelectionRequest = PoSelectionRequest(
-                            PoSelector(SeCommonProtocols.PROTOCOL_ISO7816_3, null,
-                                    SeSelector.AidSelector(
-                                            SeSelector.AidSelector.IsoAid(poAid)),
-                                            PoSelector.InvalidatedPo.REJECT))
+                            PoSelector.builder()
+                                    .seProtocol(SeCommonProtocols.PROTOCOL_ISO7816_3)
+                                    .aidSelector(SeSelector.AidSelector.builder().aidToSelect(poAid).build())
+                                        .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build())
                     seSelection.prepareSelection(poSelectionRequest)
 
                     try {
@@ -118,10 +118,10 @@ class CalypsoExamplesActivity : ExamplesActivity() {
                      */
                     val seSelection = SeSelection()
                     val poSelectionRequest = PoSelectionRequest(
-                            PoSelector(SeCommonProtocols.PROTOCOL_ISO7816_3, null,
-                                    SeSelector.AidSelector(
-                                            SeSelector.AidSelector.IsoAid(poAid)),
-                                            PoSelector.InvalidatedPo.REJECT))
+                            PoSelector.builder()
+                                    .seProtocol(SeCommonProtocols.PROTOCOL_ISO7816_3)
+                                    .aidSelector(SeSelector.AidSelector.builder().aidToSelect(poAid).build())
+                                    .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build())
 
                     /*
                      * Prepare the reading order and keep the associated parser for later use once
@@ -193,10 +193,10 @@ class CalypsoExamplesActivity : ExamplesActivity() {
                      * attributes to make the selection and read additional information afterwards
                      */
                     val poSelectionRequest = PoSelectionRequest(
-                            PoSelector(SeCommonProtocols.PROTOCOL_ISO7816_3, null,
-                                    SeSelector.AidSelector(
-                                            SeSelector.AidSelector.IsoAid(poAid)),
-                                    PoSelector.InvalidatedPo.REJECT))
+                            PoSelector.builder()
+                                    .seProtocol(SeCommonProtocols.PROTOCOL_ISO7816_3)
+                                    .aidSelector(SeSelector.AidSelector.builder().aidToSelect(poAid).build())
+                                    .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build())
 
                     /*
                      * Prepare the reading order and keep the associated parser for later use once

--- a/java/example/calypso/android/omapi/src/main/kotlin/org/eclipse/keyple/example/calypso/android/omapi/activity/CalypsoExamplesActivity.kt
+++ b/java/example/calypso/android/omapi/src/main/kotlin/org/eclipse/keyple/example/calypso/android/omapi/activity/CalypsoExamplesActivity.kt
@@ -17,11 +17,12 @@ import kotlinx.android.synthetic.main.activity_calypso_example.toolbar
 import org.eclipse.keyple.calypso.transaction.CalypsoPo
 import org.eclipse.keyple.calypso.transaction.PoSelectionRequest
 import org.eclipse.keyple.calypso.transaction.PoSelector
+import org.eclipse.keyple.calypso.transaction.PoSelector.InvalidatedPo
 import org.eclipse.keyple.core.selection.SeSelection
 import org.eclipse.keyple.core.seproxy.ChannelControl
 import org.eclipse.keyple.core.seproxy.MultiSeRequestProcessing
 import org.eclipse.keyple.core.seproxy.SeReader
-import org.eclipse.keyple.core.seproxy.SeSelector
+import org.eclipse.keyple.core.seproxy.SeSelector.AidSelector
 import org.eclipse.keyple.core.seproxy.protocol.SeCommonProtocols
 import org.eclipse.keyple.core.util.ByteArrayUtil
 import org.eclipse.keyple.example.calypso.android.omapi.R
@@ -62,8 +63,8 @@ class CalypsoExamplesActivity : ExamplesActivity() {
                     val poSelectionRequest = PoSelectionRequest(
                             PoSelector.builder()
                                     .seProtocol(SeCommonProtocols.PROTOCOL_ISO7816_3)
-                                    .aidSelector(SeSelector.AidSelector.builder().aidToSelect(poAid).build())
-                                        .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build())
+                                    .aidSelector(AidSelector.builder().aidToSelect(poAid).build())
+                                        .invalidatedPo(InvalidatedPo.REJECT).build())
                     seSelection.prepareSelection(poSelectionRequest)
 
                     try {
@@ -120,8 +121,8 @@ class CalypsoExamplesActivity : ExamplesActivity() {
                     val poSelectionRequest = PoSelectionRequest(
                             PoSelector.builder()
                                     .seProtocol(SeCommonProtocols.PROTOCOL_ISO7816_3)
-                                    .aidSelector(SeSelector.AidSelector.builder().aidToSelect(poAid).build())
-                                    .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build())
+                                    .aidSelector(AidSelector.builder().aidToSelect(poAid).build())
+                                    .invalidatedPo(InvalidatedPo.REJECT).build())
 
                     /*
                      * Prepare the reading order and keep the associated parser for later use once
@@ -195,8 +196,8 @@ class CalypsoExamplesActivity : ExamplesActivity() {
                     val poSelectionRequest = PoSelectionRequest(
                             PoSelector.builder()
                                     .seProtocol(SeCommonProtocols.PROTOCOL_ISO7816_3)
-                                    .aidSelector(SeSelector.AidSelector.builder().aidToSelect(poAid).build())
-                                    .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build())
+                                    .aidSelector(AidSelector.builder().aidToSelect(poAid).build())
+                                    .invalidatedPo(InvalidatedPo.REJECT).build())
 
                     /*
                      * Prepare the reading order and keep the associated parser for later use once

--- a/java/example/calypso/android/omapi/src/main/kotlin/org/eclipse/keyple/example/calypso/android/omapi/activity/CoreExamplesActivity.kt
+++ b/java/example/calypso/android/omapi/src/main/kotlin/org/eclipse/keyple/example/calypso/android/omapi/activity/CoreExamplesActivity.kt
@@ -19,6 +19,7 @@ import org.eclipse.keyple.core.seproxy.ChannelControl
 import org.eclipse.keyple.core.seproxy.MultiSeRequestProcessing
 import org.eclipse.keyple.core.seproxy.SeReader
 import org.eclipse.keyple.core.seproxy.SeSelector
+import org.eclipse.keyple.core.seproxy.SeSelector.AidSelector
 import org.eclipse.keyple.core.seproxy.exception.KeypleReaderException
 import org.eclipse.keyple.core.seproxy.message.ProxyReader
 import org.eclipse.keyple.core.seproxy.message.SeRequest
@@ -73,7 +74,7 @@ class CoreExamplesActivity : ExamplesActivity() {
 
                     val seSelector = SeSelector.builder()
                             .seProtocol(SeCommonProtocols.PROTOCOL_ISO7816_3)
-                            .aidSelector(SeSelector.AidSelector.builder().aidToSelect(poAid).build())
+                            .aidSelector(AidSelector.builder().aidToSelect(poAid).build())
                             .build()
                     val seRequest = SeRequest(seSelector, null)
 
@@ -113,30 +114,30 @@ class CoreExamplesActivity : ExamplesActivity() {
         seSelection.prepareSelection(GenericSeSelectionRequest(
                 SeSelector.builder()
                         .seProtocol(SeCommonProtocols.PROTOCOL_ISO7816_3)
-                        .aidSelector(SeSelector.AidSelector.builder()
+                        .aidSelector(AidSelector.builder()
                                 .aidToSelect(seAidPrefix)
-                                .fileOccurrence(SeSelector.AidSelector.FileOccurrence.FIRST)
-                                .fileControlInformation(SeSelector.AidSelector.FileControlInformation.FCI).build())
+                                .fileOccurrence(AidSelector.FileOccurrence.FIRST)
+                                .fileControlInformation(AidSelector.FileControlInformation.FCI).build())
                         .build()))
 
         /* next selection (2nd selection, later indexed 1) */
         seSelection.prepareSelection(GenericSeSelectionRequest(
                 SeSelector.builder()
                 .seProtocol(SeCommonProtocols.PROTOCOL_ISO7816_3)
-                .aidSelector(SeSelector.AidSelector.builder()
+                .aidSelector(AidSelector.builder()
                         .aidToSelect(seAidPrefix)
-                        .fileOccurrence(SeSelector.AidSelector.FileOccurrence.NEXT)
-                        .fileControlInformation(SeSelector.AidSelector.FileControlInformation.FCI).build())
+                        .fileOccurrence(AidSelector.FileOccurrence.NEXT)
+                        .fileControlInformation(AidSelector.FileControlInformation.FCI).build())
                 .build()))
 
         /* next selection (3rd selection, later indexed 2) */
         seSelection.prepareSelection(GenericSeSelectionRequest(
                 SeSelector.builder()
                         .seProtocol(SeCommonProtocols.PROTOCOL_ISO7816_3)
-                        .aidSelector(SeSelector.AidSelector.builder()
+                        .aidSelector(AidSelector.builder()
                                 .aidToSelect(seAidPrefix)
-                                .fileOccurrence(SeSelector.AidSelector.FileOccurrence.NEXT)
-                                .fileControlInformation(SeSelector.AidSelector.FileControlInformation.FCI).build())
+                                .fileOccurrence(AidSelector.FileOccurrence.NEXT)
+                                .fileControlInformation(AidSelector.FileControlInformation.FCI).build())
                         .build()))
 
         /*
@@ -197,10 +198,10 @@ class CoreExamplesActivity : ExamplesActivity() {
                     seSelection.prepareSelection(GenericSeSelectionRequest(
                             SeSelector.builder()
                                     .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                                    .aidSelector(SeSelector.AidSelector.builder()
+                                    .aidSelector(AidSelector.builder()
                                             .aidToSelect(seAidPrefix)
-                                            .fileOccurrence(SeSelector.AidSelector.FileOccurrence.FIRST)
-                                            .fileControlInformation(SeSelector.AidSelector.FileControlInformation.FCI).build())
+                                            .fileOccurrence(AidSelector.FileOccurrence.FIRST)
+                                            .fileControlInformation(AidSelector.FileControlInformation.FCI).build())
                                     .build()))
                     /* Do the selection and display the result */
                     doAndAnalyseSelection(seReader, seSelection, 1, seAidPrefix)
@@ -215,10 +216,10 @@ class CoreExamplesActivity : ExamplesActivity() {
                     seSelection.prepareSelection(GenericSeSelectionRequest(
                             SeSelector.builder()
                                     .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                                    .aidSelector(SeSelector.AidSelector.builder()
+                                    .aidSelector(AidSelector.builder()
                                             .aidToSelect(seAidPrefix)
-                                            .fileOccurrence(SeSelector.AidSelector.FileOccurrence.NEXT)
-                                            .fileControlInformation(SeSelector.AidSelector.FileControlInformation.FCI).build())
+                                            .fileOccurrence(AidSelector.FileOccurrence.NEXT)
+                                            .fileControlInformation(AidSelector.FileControlInformation.FCI).build())
                                     .build()))
 
                     /* Do the selection and display the result */

--- a/java/example/calypso/android/omapi/src/main/kotlin/org/eclipse/keyple/example/calypso/android/omapi/activity/CoreExamplesActivity.kt
+++ b/java/example/calypso/android/omapi/src/main/kotlin/org/eclipse/keyple/example/calypso/android/omapi/activity/CoreExamplesActivity.kt
@@ -71,13 +71,15 @@ class CoreExamplesActivity : ExamplesActivity() {
                 readers.forEach {
                     addHeaderEvent("Starting explicitAidSelection with $poAid on Reader ${it.name}")
 
-                    val seSelector = SeSelector(SeCommonProtocols.PROTOCOL_ISO7816_3, null,
-                            SeSelector.AidSelector(SeSelector.AidSelector.IsoAid(poAid)))
+                    val seSelector = SeSelector.builder()
+                            .seProtocol(SeCommonProtocols.PROTOCOL_ISO7816_3)
+                            .aidSelector(SeSelector.AidSelector.builder().aidToSelect(poAid).build())
+                            .build()
                     val seRequest = SeRequest(seSelector, null)
 
                     addActionEvent("Sending SeRequest to select: $poAid")
                     try {
-                        val seResponse = (it as ProxyReader).transmit(seRequest)
+                        val seResponse = (it as ProxyReader).transmitSeRequest(seRequest, ChannelControl.KEEP_OPEN)
 
                         if (seResponse?.selectionStatus?.hasMatched() == true) {
                             addResultEvent("The selection of the PO has succeeded.")
@@ -108,25 +110,34 @@ class CoreExamplesActivity : ExamplesActivity() {
         val seAidPrefix = "A000000404012509"
 
         /* AID based selection (1st selection, later indexed 0) */
-        seSelection.prepareSelection(GenericSeSelectionRequest(SeSelector(
-                SeCommonProtocols.PROTOCOL_ISO7816_3, null,
-                SeSelector.AidSelector(SeSelector.AidSelector.IsoAid(seAidPrefix),
-                        SeSelector.AidSelector.FileOccurrence.FIRST,
-                        SeSelector.AidSelector.FileControlInformation.FCI))))
+        seSelection.prepareSelection(GenericSeSelectionRequest(
+                SeSelector.builder()
+                        .seProtocol(SeCommonProtocols.PROTOCOL_ISO7816_3)
+                        .aidSelector(SeSelector.AidSelector.builder()
+                                .aidToSelect(seAidPrefix)
+                                .fileOccurrence(SeSelector.AidSelector.FileOccurrence.FIRST)
+                                .fileControlInformation(SeSelector.AidSelector.FileControlInformation.FCI).build())
+                        .build()))
 
         /* next selection (2nd selection, later indexed 1) */
-        seSelection.prepareSelection(GenericSeSelectionRequest(SeSelector(
-                SeCommonProtocols.PROTOCOL_ISO7816_3, null,
-                SeSelector.AidSelector(SeSelector.AidSelector.IsoAid(seAidPrefix),
-                        SeSelector.AidSelector.FileOccurrence.NEXT,
-                        SeSelector.AidSelector.FileControlInformation.FCI))))
+        seSelection.prepareSelection(GenericSeSelectionRequest(
+                SeSelector.builder()
+                .seProtocol(SeCommonProtocols.PROTOCOL_ISO7816_3)
+                .aidSelector(SeSelector.AidSelector.builder()
+                        .aidToSelect(seAidPrefix)
+                        .fileOccurrence(SeSelector.AidSelector.FileOccurrence.NEXT)
+                        .fileControlInformation(SeSelector.AidSelector.FileControlInformation.FCI).build())
+                .build()))
 
         /* next selection (3rd selection, later indexed 2) */
-        seSelection.prepareSelection(GenericSeSelectionRequest(SeSelector(
-                SeCommonProtocols.PROTOCOL_ISO7816_3, null,
-                SeSelector.AidSelector(SeSelector.AidSelector.IsoAid(seAidPrefix),
-                        SeSelector.AidSelector.FileOccurrence.NEXT,
-                        SeSelector.AidSelector.FileControlInformation.FCI))))
+        seSelection.prepareSelection(GenericSeSelectionRequest(
+                SeSelector.builder()
+                        .seProtocol(SeCommonProtocols.PROTOCOL_ISO7816_3)
+                        .aidSelector(SeSelector.AidSelector.builder()
+                                .aidToSelect(seAidPrefix)
+                                .fileOccurrence(SeSelector.AidSelector.FileOccurrence.NEXT)
+                                .fileControlInformation(SeSelector.AidSelector.FileControlInformation.FCI).build())
+                        .build()))
 
         /*
          * Actual SE communication: operate through a single request the SE selection
@@ -183,12 +194,14 @@ class CoreExamplesActivity : ExamplesActivity() {
                      * AID based selection: get the first application occurrence matching the AID, keep the
                      * physical channel open
                      */
-                    seSelection.prepareSelection(GenericSeSelectionRequest(SeSelector(
-                            SeCommonProtocols.PROTOCOL_ISO14443_4,
-                            null,
-                            SeSelector.AidSelector(
-                                    SeSelector.AidSelector.IsoAid(ByteArrayUtil.fromHex(seAidPrefix)), SeSelector.AidSelector.FileOccurrence.FIRST,
-                                    SeSelector.AidSelector.FileControlInformation.FCI))))
+                    seSelection.prepareSelection(GenericSeSelectionRequest(
+                            SeSelector.builder()
+                                    .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                                    .aidSelector(SeSelector.AidSelector.builder()
+                                            .aidToSelect(seAidPrefix)
+                                            .fileOccurrence(SeSelector.AidSelector.FileOccurrence.FIRST)
+                                            .fileControlInformation(SeSelector.AidSelector.FileControlInformation.FCI).build())
+                                    .build()))
                     /* Do the selection and display the result */
                     doAndAnalyseSelection(seReader, seSelection, 1, seAidPrefix)
 
@@ -199,12 +212,14 @@ class CoreExamplesActivity : ExamplesActivity() {
                     seSelection = SeSelection(MultiSeRequestProcessing.FIRST_MATCH,
                             ChannelControl.CLOSE_AFTER)
 
-                    seSelection.prepareSelection(GenericSeSelectionRequest(SeSelector(
-                            SeCommonProtocols.PROTOCOL_ISO14443_4,
-                            null,
-                            SeSelector.AidSelector(
-                                    SeSelector.AidSelector.IsoAid(ByteArrayUtil.fromHex(seAidPrefix)), SeSelector.AidSelector.FileOccurrence.NEXT,
-                                    SeSelector.AidSelector.FileControlInformation.FCI))))
+                    seSelection.prepareSelection(GenericSeSelectionRequest(
+                            SeSelector.builder()
+                                    .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                                    .aidSelector(SeSelector.AidSelector.builder()
+                                            .aidToSelect(seAidPrefix)
+                                            .fileOccurrence(SeSelector.AidSelector.FileOccurrence.NEXT)
+                                            .fileControlInformation(SeSelector.AidSelector.FileControlInformation.FCI).build())
+                                    .build()))
 
                     /* Do the selection and display the result */
                     doAndAnalyseSelection(seReader, seSelection, 2, seAidPrefix)

--- a/java/example/calypso/pc/UseCase1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase1/ExplicitSelectionAid_Pcsc.java
+++ b/java/example/calypso/pc/UseCase1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase1/ExplicitSelectionAid_Pcsc.java
@@ -13,6 +13,7 @@ package org.eclipse.keyple.example.calypso.pc.usecase1;
 
 
 
+import static org.eclipse.keyple.calypso.transaction.PoSelector.*;
 import org.eclipse.keyple.calypso.transaction.CalypsoPo;
 import org.eclipse.keyple.calypso.transaction.ElementaryFile;
 import org.eclipse.keyple.calypso.transaction.PoResource;
@@ -23,7 +24,6 @@ import org.eclipse.keyple.core.selection.SeSelection;
 import org.eclipse.keyple.core.seproxy.ChannelControl;
 import org.eclipse.keyple.core.seproxy.SeProxyService;
 import org.eclipse.keyple.core.seproxy.SeReader;
-import org.eclipse.keyple.core.seproxy.SeSelector;
 import org.eclipse.keyple.core.seproxy.exception.KeypleException;
 import org.eclipse.keyple.core.seproxy.protocol.SeCommonProtocols;
 import org.eclipse.keyple.core.util.ByteArrayUtil;
@@ -70,11 +70,6 @@ public class ExplicitSelectionAid_Pcsc {
         // CalypsoUtilities class.
         SeReader poReader = CalypsoUtilities.getDefaultPoReader();
 
-        // Check if the reader exists
-        if (poReader == null) {
-            throw new IllegalStateException("Bad PO reader setup");
-        }
-
         logger.info(
                 "=============== UseCase Calypso #1: AID based explicit selection ==================");
         logger.info("= PO Reader  NAME = {}", poReader.getName());
@@ -95,11 +90,10 @@ public class ExplicitSelectionAid_Pcsc {
 
             // Calypso selection: configures a PoSelectionRequest with all the desired attributes to
             // make the selection and read additional information afterwards
-            PoSelectionRequest poSelectionRequest = new PoSelectionRequest(
-                    PoSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                            .aidSelector(SeSelector.AidSelector.builder()
-                                    .aidToSelect(CalypsoClassicInfo.AID).build())
-                            .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
+            PoSelectionRequest poSelectionRequest = new PoSelectionRequest(PoSelector.builder()
+                    .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                    .aidSelector(AidSelector.builder().aidToSelect(CalypsoClassicInfo.AID).build())
+                    .invalidatedPo(InvalidatedPo.REJECT).build());
 
             // Prepare the reading order.
             poSelectionRequest.prepareReadRecordFile(CalypsoClassicInfo.SFI_EnvironmentAndHolder,

--- a/java/example/calypso/pc/UseCase1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase1/ExplicitSelectionAid_Pcsc.java
+++ b/java/example/calypso/pc/UseCase1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase1/ExplicitSelectionAid_Pcsc.java
@@ -96,10 +96,10 @@ public class ExplicitSelectionAid_Pcsc {
             // Calypso selection: configures a PoSelectionRequest with all the desired attributes to
             // make the selection and read additional information afterwards
             PoSelectionRequest poSelectionRequest = new PoSelectionRequest(
-                    new PoSelector(SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                            new PoSelector.AidSelector(
-                                    new SeSelector.AidSelector.IsoAid(CalypsoClassicInfo.AID)),
-                            PoSelector.InvalidatedPo.REJECT));
+                    new PoSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                            .aidSelector(new SeSelector.AidSelector.Builder()
+                                    .aidToSelect(CalypsoClassicInfo.AID).build())
+                            .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
 
             // Prepare the reading order.
             poSelectionRequest.prepareReadRecordFile(CalypsoClassicInfo.SFI_EnvironmentAndHolder,

--- a/java/example/calypso/pc/UseCase1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase1/ExplicitSelectionAid_Pcsc.java
+++ b/java/example/calypso/pc/UseCase1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase1/ExplicitSelectionAid_Pcsc.java
@@ -96,8 +96,8 @@ public class ExplicitSelectionAid_Pcsc {
             // Calypso selection: configures a PoSelectionRequest with all the desired attributes to
             // make the selection and read additional information afterwards
             PoSelectionRequest poSelectionRequest = new PoSelectionRequest(
-                    new PoSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                            .aidSelector(new SeSelector.AidSelector.Builder()
+                    PoSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                            .aidSelector(SeSelector.AidSelector.builder()
                                     .aidToSelect(CalypsoClassicInfo.AID).build())
                             .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
 

--- a/java/example/calypso/pc/UseCase1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase1/ExplicitSelectionAid_Stub.java
+++ b/java/example/calypso/pc/UseCase1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase1/ExplicitSelectionAid_Stub.java
@@ -113,10 +113,10 @@ public class ExplicitSelectionAid_Stub {
             // Calypso selection: configures a PoSelectionRequest with all the desired attributes to
             // make the selection and read additional information afterwards
             PoSelectionRequest poSelectionRequest = new PoSelectionRequest(
-                    new PoSelector(SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                            new PoSelector.AidSelector(
-                                    new SeSelector.AidSelector.IsoAid(CalypsoClassicInfo.AID)),
-                            PoSelector.InvalidatedPo.REJECT));
+                    new PoSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                            .aidSelector(new SeSelector.AidSelector.Builder()
+                                    .aidToSelect(CalypsoClassicInfo.AID).build())
+                            .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
 
             // Prepare the reading order.
             poSelectionRequest.prepareReadRecordFile(CalypsoClassicInfo.SFI_EnvironmentAndHolder,

--- a/java/example/calypso/pc/UseCase1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase1/ExplicitSelectionAid_Stub.java
+++ b/java/example/calypso/pc/UseCase1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase1/ExplicitSelectionAid_Stub.java
@@ -113,8 +113,8 @@ public class ExplicitSelectionAid_Stub {
             // Calypso selection: configures a PoSelectionRequest with all the desired attributes to
             // make the selection and read additional information afterwards
             PoSelectionRequest poSelectionRequest = new PoSelectionRequest(
-                    new PoSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                            .aidSelector(new SeSelector.AidSelector.Builder()
+                    PoSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                            .aidSelector(SeSelector.AidSelector.builder()
                                     .aidToSelect(CalypsoClassicInfo.AID).build())
                             .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
 

--- a/java/example/calypso/pc/UseCase1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase1/ExplicitSelectionAid_Stub.java
+++ b/java/example/calypso/pc/UseCase1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase1/ExplicitSelectionAid_Stub.java
@@ -13,6 +13,7 @@ package org.eclipse.keyple.example.calypso.pc.usecase1;
 
 
 
+import static org.eclipse.keyple.calypso.transaction.PoSelector.*;
 import org.eclipse.keyple.calypso.transaction.CalypsoPo;
 import org.eclipse.keyple.calypso.transaction.ElementaryFile;
 import org.eclipse.keyple.calypso.transaction.PoResource;
@@ -23,7 +24,6 @@ import org.eclipse.keyple.core.selection.SeSelection;
 import org.eclipse.keyple.core.seproxy.ChannelControl;
 import org.eclipse.keyple.core.seproxy.ReaderPlugin;
 import org.eclipse.keyple.core.seproxy.SeProxyService;
-import org.eclipse.keyple.core.seproxy.SeSelector;
 import org.eclipse.keyple.core.seproxy.exception.KeypleException;
 import org.eclipse.keyple.core.seproxy.protocol.SeCommonProtocols;
 import org.eclipse.keyple.core.util.ByteArrayUtil;
@@ -112,11 +112,10 @@ public class ExplicitSelectionAid_Stub {
 
             // Calypso selection: configures a PoSelectionRequest with all the desired attributes to
             // make the selection and read additional information afterwards
-            PoSelectionRequest poSelectionRequest = new PoSelectionRequest(
-                    PoSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                            .aidSelector(SeSelector.AidSelector.builder()
-                                    .aidToSelect(CalypsoClassicInfo.AID).build())
-                            .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
+            PoSelectionRequest poSelectionRequest = new PoSelectionRequest(PoSelector.builder()
+                    .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                    .aidSelector(AidSelector.builder().aidToSelect(CalypsoClassicInfo.AID).build())
+                    .invalidatedPo(InvalidatedPo.REJECT).build());
 
             // Prepare the reading order.
             poSelectionRequest.prepareReadRecordFile(CalypsoClassicInfo.SFI_EnvironmentAndHolder,

--- a/java/example/calypso/pc/UseCase2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase2/DefaultSelectionNotification_Pcsc.java
+++ b/java/example/calypso/pc/UseCase2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase2/DefaultSelectionNotification_Pcsc.java
@@ -100,7 +100,7 @@ public class DefaultSelectionNotification_Pcsc implements ReaderObserver {
         // Calypso selection: configures a PoSelectionRequest with all the desired attributes to
         // make the selection and read additional information afterwards
         PoSelectionRequest poSelectionRequest = new PoSelectionRequest(
-                new PoSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                PoSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
                         .aidSelector(new PoSelector.AidSelector.Builder()
                                 .aidToSelect(CalypsoClassicInfo.AID).build())
                         .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());

--- a/java/example/calypso/pc/UseCase2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase2/DefaultSelectionNotification_Pcsc.java
+++ b/java/example/calypso/pc/UseCase2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase2/DefaultSelectionNotification_Pcsc.java
@@ -99,11 +99,11 @@ public class DefaultSelectionNotification_Pcsc implements ReaderObserver {
 
         // Calypso selection: configures a PoSelectionRequest with all the desired attributes to
         // make the selection and read additional information afterwards
-        PoSelectionRequest poSelectionRequest =
-                new PoSelectionRequest(new PoSelector(SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                        new PoSelector.AidSelector(
-                                new PoSelector.AidSelector.IsoAid(CalypsoClassicInfo.AID)),
-                        PoSelector.InvalidatedPo.REJECT));
+        PoSelectionRequest poSelectionRequest = new PoSelectionRequest(
+                new PoSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                        .aidSelector(new PoSelector.AidSelector.Builder()
+                                .aidToSelect(CalypsoClassicInfo.AID).build())
+                        .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
 
         // Prepare the reading.
         poSelectionRequest.prepareReadRecordFile(CalypsoClassicInfo.SFI_EnvironmentAndHolder,

--- a/java/example/calypso/pc/UseCase2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase2/DefaultSelectionNotification_Pcsc.java
+++ b/java/example/calypso/pc/UseCase2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase2/DefaultSelectionNotification_Pcsc.java
@@ -101,7 +101,7 @@ public class DefaultSelectionNotification_Pcsc implements ReaderObserver {
         // make the selection and read additional information afterwards
         PoSelectionRequest poSelectionRequest = new PoSelectionRequest(
                 PoSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                        .aidSelector(new PoSelector.AidSelector.Builder()
+                        .aidSelector(PoSelector.AidSelector.builder()
                                 .aidToSelect(CalypsoClassicInfo.AID).build())
                         .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
 

--- a/java/example/calypso/pc/UseCase2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase2/DefaultSelectionNotification_Pcsc.java
+++ b/java/example/calypso/pc/UseCase2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase2/DefaultSelectionNotification_Pcsc.java
@@ -11,7 +11,7 @@
  ********************************************************************************/
 package org.eclipse.keyple.example.calypso.pc.usecase2;
 
-
+import static org.eclipse.keyple.calypso.transaction.PoSelector.*;
 import org.eclipse.keyple.calypso.command.po.exception.CalypsoPoCommandException;
 import org.eclipse.keyple.calypso.transaction.CalypsoPo;
 import org.eclipse.keyple.calypso.transaction.ElementaryFile;
@@ -99,11 +99,10 @@ public class DefaultSelectionNotification_Pcsc implements ReaderObserver {
 
         // Calypso selection: configures a PoSelectionRequest with all the desired attributes to
         // make the selection and read additional information afterwards
-        PoSelectionRequest poSelectionRequest = new PoSelectionRequest(
-                PoSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                        .aidSelector(PoSelector.AidSelector.builder()
-                                .aidToSelect(CalypsoClassicInfo.AID).build())
-                        .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
+        PoSelectionRequest poSelectionRequest = new PoSelectionRequest(PoSelector.builder()
+                .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                .aidSelector(AidSelector.builder().aidToSelect(CalypsoClassicInfo.AID).build())
+                .invalidatedPo(InvalidatedPo.REJECT).build());
 
         // Prepare the reading.
         poSelectionRequest.prepareReadRecordFile(CalypsoClassicInfo.SFI_EnvironmentAndHolder,

--- a/java/example/calypso/pc/UseCase2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase2/DefaultSelectionNotification_Stub.java
+++ b/java/example/calypso/pc/UseCase2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase2/DefaultSelectionNotification_Stub.java
@@ -12,6 +12,7 @@
 package org.eclipse.keyple.example.calypso.pc.usecase2;
 
 
+import static org.eclipse.keyple.calypso.transaction.PoSelector.*;
 import org.eclipse.keyple.calypso.command.po.exception.CalypsoPoCommandException;
 import org.eclipse.keyple.calypso.transaction.CalypsoPo;
 import org.eclipse.keyple.calypso.transaction.ElementaryFile;
@@ -25,7 +26,6 @@ import org.eclipse.keyple.core.seproxy.ChannelControl;
 import org.eclipse.keyple.core.seproxy.ReaderPlugin;
 import org.eclipse.keyple.core.seproxy.SeProxyService;
 import org.eclipse.keyple.core.seproxy.SeReader;
-import org.eclipse.keyple.core.seproxy.SeSelector;
 import org.eclipse.keyple.core.seproxy.event.ObservableReader;
 import org.eclipse.keyple.core.seproxy.event.ObservableReader.ReaderObserver;
 import org.eclipse.keyple.core.seproxy.event.ReaderEvent;
@@ -120,11 +120,10 @@ public class DefaultSelectionNotification_Stub implements ReaderObserver {
          * Calypso selection: configures a PoSelectionRequest with all the desired attributes to
          * make the selection and read additional information afterwards
          */
-        PoSelectionRequest poSelectionRequest = new PoSelectionRequest(
-                PoSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                        .aidSelector(SeSelector.AidSelector.builder()
-                                .aidToSelect(CalypsoClassicInfo.AID).build())
-                        .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
+        PoSelectionRequest poSelectionRequest = new PoSelectionRequest(PoSelector.builder()
+                .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                .aidSelector(AidSelector.builder().aidToSelect(CalypsoClassicInfo.AID).build())
+                .invalidatedPo(InvalidatedPo.REJECT).build());
 
         /*
          * Prepare the reading order.

--- a/java/example/calypso/pc/UseCase2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase2/DefaultSelectionNotification_Stub.java
+++ b/java/example/calypso/pc/UseCase2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase2/DefaultSelectionNotification_Stub.java
@@ -120,11 +120,11 @@ public class DefaultSelectionNotification_Stub implements ReaderObserver {
          * Calypso selection: configures a PoSelectionRequest with all the desired attributes to
          * make the selection and read additional information afterwards
          */
-        PoSelectionRequest poSelectionRequest =
-                new PoSelectionRequest(new PoSelector(SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                        new PoSelector.AidSelector(
-                                new SeSelector.AidSelector.IsoAid(CalypsoClassicInfo.AID)),
-                        PoSelector.InvalidatedPo.REJECT));
+        PoSelectionRequest poSelectionRequest = new PoSelectionRequest(
+                new PoSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                        .aidSelector(new SeSelector.AidSelector.Builder()
+                                .aidToSelect(CalypsoClassicInfo.AID).build())
+                        .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
 
         /*
          * Prepare the reading order.

--- a/java/example/calypso/pc/UseCase2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase2/DefaultSelectionNotification_Stub.java
+++ b/java/example/calypso/pc/UseCase2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase2/DefaultSelectionNotification_Stub.java
@@ -121,8 +121,8 @@ public class DefaultSelectionNotification_Stub implements ReaderObserver {
          * make the selection and read additional information afterwards
          */
         PoSelectionRequest poSelectionRequest = new PoSelectionRequest(
-                new PoSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                        .aidSelector(new SeSelector.AidSelector.Builder()
+                PoSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                        .aidSelector(SeSelector.AidSelector.builder()
                                 .aidToSelect(CalypsoClassicInfo.AID).build())
                         .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
 

--- a/java/example/calypso/pc/UseCase3_Rev1Selection/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase3/Rev1Selection_Pcsc.java
+++ b/java/example/calypso/pc/UseCase3_Rev1Selection/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase3/Rev1Selection_Pcsc.java
@@ -94,7 +94,7 @@ public class Rev1Selection_Pcsc {
             // Calypso selection: configures a PoSelectionRequest with all the desired attributes to
             // make the selection and read additional information afterwards
             PoSelectionRequest poSelectionRequest = new PoSelectionRequest(
-                    new PoSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_B_PRIME)
+                    PoSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_B_PRIME)
                             .atrFilter(new PoSelector.AtrFilter(PO_ATR_REGEX))
                             .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
 

--- a/java/example/calypso/pc/UseCase3_Rev1Selection/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase3/Rev1Selection_Pcsc.java
+++ b/java/example/calypso/pc/UseCase3_Rev1Selection/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase3/Rev1Selection_Pcsc.java
@@ -93,10 +93,10 @@ public class Rev1Selection_Pcsc {
 
             // Calypso selection: configures a PoSelectionRequest with all the desired attributes to
             // make the selection and read additional information afterwards
-            PoSelectionRequest poSelectionRequest =
-                    new PoSelectionRequest(new PoSelector(SeCommonProtocols.PROTOCOL_B_PRIME,
-                            new PoSelector.AtrFilter(PO_ATR_REGEX), null,
-                            PoSelector.InvalidatedPo.REJECT));
+            PoSelectionRequest poSelectionRequest = new PoSelectionRequest(
+                    new PoSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_B_PRIME)
+                            .atrFilter(new PoSelector.AtrFilter(PO_ATR_REGEX))
+                            .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
 
             // Prepare the selection of the DF RT.
             poSelectionRequest.prepareSelectFile(ByteArrayUtil.fromHex(PO_DF_RT_PATH));

--- a/java/example/calypso/pc/UseCase3_Rev1Selection/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase3/Rev1Selection_Pcsc.java
+++ b/java/example/calypso/pc/UseCase3_Rev1Selection/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase3/Rev1Selection_Pcsc.java
@@ -12,6 +12,7 @@
 package org.eclipse.keyple.example.calypso.pc.usecase3;
 
 
+import static org.eclipse.keyple.calypso.transaction.PoSelector.*;
 import org.eclipse.keyple.calypso.transaction.CalypsoPo;
 import org.eclipse.keyple.calypso.transaction.ElementaryFile;
 import org.eclipse.keyple.calypso.transaction.PoResource;
@@ -95,8 +96,8 @@ public class Rev1Selection_Pcsc {
             // make the selection and read additional information afterwards
             PoSelectionRequest poSelectionRequest = new PoSelectionRequest(
                     PoSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_B_PRIME)
-                            .atrFilter(new PoSelector.AtrFilter(PO_ATR_REGEX))
-                            .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
+                            .atrFilter(new AtrFilter(PO_ATR_REGEX))
+                            .invalidatedPo(InvalidatedPo.REJECT).build());
 
             // Prepare the selection of the DF RT.
             poSelectionRequest.prepareSelectFile(ByteArrayUtil.fromHex(PO_DF_RT_PATH));

--- a/java/example/calypso/pc/UseCase4_PoAuthentication/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase4/PoAuthentication_Pcsc.java
+++ b/java/example/calypso/pc/UseCase4_PoAuthentication/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase4/PoAuthentication_Pcsc.java
@@ -99,10 +99,11 @@ public class PoAuthentication_Pcsc {
 
             // Calypso selection: configures a PoSelectionRequest with all the desired attributes to
             // make the selection and read additional information afterwards
-            PoSelectionRequest poSelectionRequest =
-                    new PoSelectionRequest(new PoSelector(SeCommonProtocols.PROTOCOL_ISO14443_4,
-                            null, new AidSelector(new AidSelector.IsoAid(CalypsoClassicInfo.AID)),
-                            PoSelector.InvalidatedPo.REJECT));
+            PoSelectionRequest poSelectionRequest = new PoSelectionRequest(new PoSelector.Builder()
+                    .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                    .aidSelector(
+                            new AidSelector.Builder().aidToSelect(CalypsoClassicInfo.AID).build())
+                    .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
 
             // Prepare the reading of the Environment and Holder file.
             poSelectionRequest.prepareReadRecordFile(CalypsoClassicInfo.SFI_EnvironmentAndHolder,

--- a/java/example/calypso/pc/UseCase4_PoAuthentication/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase4/PoAuthentication_Pcsc.java
+++ b/java/example/calypso/pc/UseCase4_PoAuthentication/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase4/PoAuthentication_Pcsc.java
@@ -101,8 +101,7 @@ public class PoAuthentication_Pcsc {
             // make the selection and read additional information afterwards
             PoSelectionRequest poSelectionRequest = new PoSelectionRequest(PoSelector.builder()
                     .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                    .aidSelector(
-                            new AidSelector.Builder().aidToSelect(CalypsoClassicInfo.AID).build())
+                    .aidSelector(AidSelector.builder().aidToSelect(CalypsoClassicInfo.AID).build())
                     .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
 
             // Prepare the reading of the Environment and Holder file.

--- a/java/example/calypso/pc/UseCase4_PoAuthentication/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase4/PoAuthentication_Pcsc.java
+++ b/java/example/calypso/pc/UseCase4_PoAuthentication/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase4/PoAuthentication_Pcsc.java
@@ -99,7 +99,7 @@ public class PoAuthentication_Pcsc {
 
             // Calypso selection: configures a PoSelectionRequest with all the desired attributes to
             // make the selection and read additional information afterwards
-            PoSelectionRequest poSelectionRequest = new PoSelectionRequest(new PoSelector.Builder()
+            PoSelectionRequest poSelectionRequest = new PoSelectionRequest(PoSelector.builder()
                     .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
                     .aidSelector(
                             new AidSelector.Builder().aidToSelect(CalypsoClassicInfo.AID).build())

--- a/java/example/calypso/pc/UseCase4_PoAuthentication/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase4/PoAuthentication_Pcsc.java
+++ b/java/example/calypso/pc/UseCase4_PoAuthentication/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase4/PoAuthentication_Pcsc.java
@@ -12,6 +12,7 @@
 package org.eclipse.keyple.example.calypso.pc.usecase4;
 
 
+import static org.eclipse.keyple.calypso.transaction.PoSelector.*;
 import org.eclipse.keyple.calypso.transaction.CalypsoPo;
 import org.eclipse.keyple.calypso.transaction.ElementaryFile;
 import org.eclipse.keyple.calypso.transaction.PoResource;
@@ -23,7 +24,6 @@ import org.eclipse.keyple.core.selection.SeSelection;
 import org.eclipse.keyple.core.seproxy.ChannelControl;
 import org.eclipse.keyple.core.seproxy.SeProxyService;
 import org.eclipse.keyple.core.seproxy.SeReader;
-import org.eclipse.keyple.core.seproxy.SeSelector.AidSelector;
 import org.eclipse.keyple.core.seproxy.exception.KeypleException;
 import org.eclipse.keyple.core.seproxy.protocol.SeCommonProtocols;
 import org.eclipse.keyple.core.util.ByteArrayUtil;
@@ -102,7 +102,7 @@ public class PoAuthentication_Pcsc {
             PoSelectionRequest poSelectionRequest = new PoSelectionRequest(PoSelector.builder()
                     .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
                     .aidSelector(AidSelector.builder().aidToSelect(CalypsoClassicInfo.AID).build())
-                    .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
+                    .invalidatedPo(InvalidatedPo.REJECT).build());
 
             // Prepare the reading of the Environment and Holder file.
             poSelectionRequest.prepareReadRecordFile(CalypsoClassicInfo.SFI_EnvironmentAndHolder,

--- a/java/example/calypso/pc/UseCase4_PoAuthentication/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase4/PoAuthentication_Stub.java
+++ b/java/example/calypso/pc/UseCase4_PoAuthentication/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase4/PoAuthentication_Stub.java
@@ -12,6 +12,7 @@
 package org.eclipse.keyple.example.calypso.pc.usecase4;
 
 
+import static org.eclipse.keyple.calypso.transaction.PoSelector.*;
 import org.eclipse.keyple.calypso.transaction.CalypsoPo;
 import org.eclipse.keyple.calypso.transaction.ElementaryFile;
 import org.eclipse.keyple.calypso.transaction.PoResource;
@@ -24,7 +25,6 @@ import org.eclipse.keyple.core.seproxy.ChannelControl;
 import org.eclipse.keyple.core.seproxy.ReaderPlugin;
 import org.eclipse.keyple.core.seproxy.SeProxyService;
 import org.eclipse.keyple.core.seproxy.SeReader;
-import org.eclipse.keyple.core.seproxy.SeSelector;
 import org.eclipse.keyple.core.seproxy.exception.KeypleException;
 import org.eclipse.keyple.core.seproxy.protocol.SeCommonProtocols;
 import org.eclipse.keyple.core.util.ByteArrayUtil;
@@ -136,11 +136,10 @@ public class PoAuthentication_Stub {
 
             // Calypso selection: configures a PoSelectionRequest with all the desired attributes to
             // make the selection and read additional information afterwards
-            PoSelectionRequest poSelectionRequest = new PoSelectionRequest(
-                    PoSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                            .aidSelector(SeSelector.AidSelector.builder()
-                                    .aidToSelect(CalypsoClassicInfo.AID).build())
-                            .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
+            PoSelectionRequest poSelectionRequest = new PoSelectionRequest(PoSelector.builder()
+                    .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                    .aidSelector(AidSelector.builder().aidToSelect(CalypsoClassicInfo.AID).build())
+                    .invalidatedPo(InvalidatedPo.REJECT).build());
 
             // Prepare the reading of the Environment and Holder file.
             poSelectionRequest.prepareReadRecordFile(CalypsoClassicInfo.SFI_EnvironmentAndHolder,

--- a/java/example/calypso/pc/UseCase4_PoAuthentication/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase4/PoAuthentication_Stub.java
+++ b/java/example/calypso/pc/UseCase4_PoAuthentication/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase4/PoAuthentication_Stub.java
@@ -137,10 +137,10 @@ public class PoAuthentication_Stub {
             // Calypso selection: configures a PoSelectionRequest with all the desired attributes to
             // make the selection and read additional information afterwards
             PoSelectionRequest poSelectionRequest = new PoSelectionRequest(
-                    new PoSelector(SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                            new SeSelector.AidSelector(
-                                    new SeSelector.AidSelector.IsoAid(CalypsoClassicInfo.AID)),
-                            PoSelector.InvalidatedPo.REJECT));
+                    new PoSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                            .aidSelector(new SeSelector.AidSelector.Builder()
+                                    .aidToSelect(CalypsoClassicInfo.AID).build())
+                            .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
 
             // Prepare the reading of the Environment and Holder file.
             poSelectionRequest.prepareReadRecordFile(CalypsoClassicInfo.SFI_EnvironmentAndHolder,

--- a/java/example/calypso/pc/UseCase4_PoAuthentication/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase4/PoAuthentication_Stub.java
+++ b/java/example/calypso/pc/UseCase4_PoAuthentication/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase4/PoAuthentication_Stub.java
@@ -137,8 +137,8 @@ public class PoAuthentication_Stub {
             // Calypso selection: configures a PoSelectionRequest with all the desired attributes to
             // make the selection and read additional information afterwards
             PoSelectionRequest poSelectionRequest = new PoSelectionRequest(
-                    new PoSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                            .aidSelector(new SeSelector.AidSelector.Builder()
+                    PoSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                            .aidSelector(SeSelector.AidSelector.builder()
                                     .aidToSelect(CalypsoClassicInfo.AID).build())
                             .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
 

--- a/java/example/calypso/pc/UseCase5_MultipleSession/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase5/MultipleSession_Pcsc.java
+++ b/java/example/calypso/pc/UseCase5_MultipleSession/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase5/MultipleSession_Pcsc.java
@@ -114,8 +114,7 @@ public class MultipleSession_Pcsc {
             // make the selection and read additional information afterwards
             PoSelectionRequest poSelectionRequest = new PoSelectionRequest(PoSelector.builder()
                     .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                    .aidSelector(
-                            new AidSelector.Builder().aidToSelect(CalypsoClassicInfo.AID).build())
+                    .aidSelector(AidSelector.builder().aidToSelect(CalypsoClassicInfo.AID).build())
                     .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
 
             // Add the selection case to the current selection (we could have added other cases

--- a/java/example/calypso/pc/UseCase5_MultipleSession/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase5/MultipleSession_Pcsc.java
+++ b/java/example/calypso/pc/UseCase5_MultipleSession/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase5/MultipleSession_Pcsc.java
@@ -12,6 +12,7 @@
 package org.eclipse.keyple.example.calypso.pc.usecase5;
 
 
+import static org.eclipse.keyple.calypso.transaction.PoSelector.*;
 import org.eclipse.keyple.calypso.transaction.CalypsoPo;
 import org.eclipse.keyple.calypso.transaction.PoResource;
 import org.eclipse.keyple.calypso.transaction.PoSecuritySettings;
@@ -23,7 +24,6 @@ import org.eclipse.keyple.core.selection.SeSelection;
 import org.eclipse.keyple.core.seproxy.ChannelControl;
 import org.eclipse.keyple.core.seproxy.SeProxyService;
 import org.eclipse.keyple.core.seproxy.SeReader;
-import org.eclipse.keyple.core.seproxy.SeSelector.AidSelector;
 import org.eclipse.keyple.core.seproxy.exception.KeypleException;
 import org.eclipse.keyple.core.seproxy.protocol.SeCommonProtocols;
 import org.eclipse.keyple.core.util.ByteArrayUtil;
@@ -115,7 +115,7 @@ public class MultipleSession_Pcsc {
             PoSelectionRequest poSelectionRequest = new PoSelectionRequest(PoSelector.builder()
                     .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
                     .aidSelector(AidSelector.builder().aidToSelect(CalypsoClassicInfo.AID).build())
-                    .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
+                    .invalidatedPo(InvalidatedPo.REJECT).build());
 
             // Add the selection case to the current selection (we could have added other cases
             // here)

--- a/java/example/calypso/pc/UseCase5_MultipleSession/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase5/MultipleSession_Pcsc.java
+++ b/java/example/calypso/pc/UseCase5_MultipleSession/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase5/MultipleSession_Pcsc.java
@@ -112,10 +112,11 @@ public class MultipleSession_Pcsc {
             // Calypso selection: configures a PoSelectionRequest with all the desired attributes
             // to
             // make the selection and read additional information afterwards
-            PoSelectionRequest poSelectionRequest =
-                    new PoSelectionRequest(new PoSelector(SeCommonProtocols.PROTOCOL_ISO14443_4,
-                            null, new AidSelector(new AidSelector.IsoAid(CalypsoClassicInfo.AID)),
-                            PoSelector.InvalidatedPo.REJECT));
+            PoSelectionRequest poSelectionRequest = new PoSelectionRequest(new PoSelector.Builder()
+                    .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                    .aidSelector(
+                            new AidSelector.Builder().aidToSelect(CalypsoClassicInfo.AID).build())
+                    .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
 
             // Add the selection case to the current selection (we could have added other cases
             // here)

--- a/java/example/calypso/pc/UseCase5_MultipleSession/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase5/MultipleSession_Pcsc.java
+++ b/java/example/calypso/pc/UseCase5_MultipleSession/src/main/java/org/eclipse/keyple/example/calypso/pc/usecase5/MultipleSession_Pcsc.java
@@ -112,7 +112,7 @@ public class MultipleSession_Pcsc {
             // Calypso selection: configures a PoSelectionRequest with all the desired attributes
             // to
             // make the selection and read additional information afterwards
-            PoSelectionRequest poSelectionRequest = new PoSelectionRequest(new PoSelector.Builder()
+            PoSelectionRequest poSelectionRequest = new PoSelectionRequest(PoSelector.builder()
                     .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
                     .aidSelector(
                             new AidSelector.Builder().aidToSelect(CalypsoClassicInfo.AID).build())

--- a/java/example/calypso/remotese/src/main/java/org/eclipse/keyple/example/remote/application/PoVirtualReaderObserver.java
+++ b/java/example/calypso/remotese/src/main/java/org/eclipse/keyple/example/remote/application/PoVirtualReaderObserver.java
@@ -101,8 +101,8 @@ public class PoVirtualReaderObserver implements ObservableReader.ReaderObserver 
                      * Get a SamResource to perform authentication
                      */
                     samResource = samResourceManager.allocateSamResource(
-                            SamResourceManager.AllocationMode.BLOCKING,
-                            new SamIdentifier(SamRevision.AUTO, ".*", ""));
+                            SamResourceManager.AllocationMode.BLOCKING, new SamIdentifier.Builder()
+                                    .samRevision(SamRevision.AUTO).serialNumber(".*").build());
 
                     if (samResource == null) {
                         throw new KeypleReaderIOException(

--- a/java/example/calypso/remotese/src/main/java/org/eclipse/keyple/example/remote/application/PoVirtualReaderObserver.java
+++ b/java/example/calypso/remotese/src/main/java/org/eclipse/keyple/example/remote/application/PoVirtualReaderObserver.java
@@ -101,7 +101,7 @@ public class PoVirtualReaderObserver implements ObservableReader.ReaderObserver 
                      * Get a SamResource to perform authentication
                      */
                     samResource = samResourceManager.allocateSamResource(
-                            SamResourceManager.AllocationMode.BLOCKING, new SamIdentifier.Builder()
+                            SamResourceManager.AllocationMode.BLOCKING, SamIdentifier.builder()
                                     .samRevision(SamRevision.AUTO).serialNumber(".*").build());
 
                     if (samResource == null) {

--- a/java/example/calypso/remotese/src/main/java/org/eclipse/keyple/example/remote/application/RemoteSePluginObserver.java
+++ b/java/example/calypso/remotese/src/main/java/org/eclipse/keyple/example/remote/application/RemoteSePluginObserver.java
@@ -85,10 +85,9 @@ public class RemoteSePluginObserver implements ObservablePlugin.PluginObserver {
                      * Calypso selection: configures a PoSelectionRequest with all the desired
                      * attributes to make the selection and read additional information afterwards
                      */
-                    PoSelectionRequest poSelectionRequest =
-                            new PoSelectionRequest(new PoSelector.Builder()
-                                    .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                                    .aidSelector(new SeSelector.AidSelector.Builder()
+                    PoSelectionRequest poSelectionRequest = new PoSelectionRequest(
+                            PoSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                                    .aidSelector(SeSelector.AidSelector.builder()
                                             .aidToSelect(CalypsoClassicInfo.AID).build())
                                     .invalidatedPo(PoSelector.InvalidatedPo.ACCEPT).build());
 

--- a/java/example/calypso/remotese/src/main/java/org/eclipse/keyple/example/remote/application/RemoteSePluginObserver.java
+++ b/java/example/calypso/remotese/src/main/java/org/eclipse/keyple/example/remote/application/RemoteSePluginObserver.java
@@ -85,11 +85,12 @@ public class RemoteSePluginObserver implements ObservablePlugin.PluginObserver {
                      * Calypso selection: configures a PoSelectionRequest with all the desired
                      * attributes to make the selection and read additional information afterwards
                      */
-                    PoSelectionRequest poSelectionRequest = new PoSelectionRequest(new PoSelector(
-                            SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                            new PoSelector.AidSelector(
-                                    new SeSelector.AidSelector.IsoAid(CalypsoClassicInfo.AID)),
-                            PoSelector.InvalidatedPo.ACCEPT));
+                    PoSelectionRequest poSelectionRequest =
+                            new PoSelectionRequest(new PoSelector.Builder()
+                                    .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                                    .aidSelector(new SeSelector.AidSelector.Builder()
+                                            .aidToSelect(CalypsoClassicInfo.AID).build())
+                                    .invalidatedPo(PoSelector.InvalidatedPo.ACCEPT).build());
 
                     logger.info("{} Create a PoSelectionRequest", nodeId);
 

--- a/java/example/calypso/remotese/src/main/java/org/eclipse/keyple/example/remote/application/RemoteSePluginObserver.java
+++ b/java/example/calypso/remotese/src/main/java/org/eclipse/keyple/example/remote/application/RemoteSePluginObserver.java
@@ -11,6 +11,7 @@
  ********************************************************************************/
 package org.eclipse.keyple.example.remote.application;
 
+import static org.eclipse.keyple.calypso.transaction.PoSelector.*;
 import org.eclipse.keyple.calypso.transaction.PoSelectionRequest;
 import org.eclipse.keyple.calypso.transaction.PoSelector;
 import org.eclipse.keyple.calypso.transaction.SamResourceManager;
@@ -20,7 +21,6 @@ import org.eclipse.keyple.core.seproxy.MultiSeRequestProcessing;
 import org.eclipse.keyple.core.seproxy.ReaderPlugin;
 import org.eclipse.keyple.core.seproxy.SeProxyService;
 import org.eclipse.keyple.core.seproxy.SeReader;
-import org.eclipse.keyple.core.seproxy.SeSelector;
 import org.eclipse.keyple.core.seproxy.event.ObservablePlugin;
 import org.eclipse.keyple.core.seproxy.event.ObservableReader;
 import org.eclipse.keyple.core.seproxy.event.PluginEvent;
@@ -40,9 +40,9 @@ public class RemoteSePluginObserver implements ObservablePlugin.PluginObserver {
 
     private static final Logger logger = LoggerFactory.getLogger(RemoteSePluginObserver.class);
 
-    final private String nodeId;
-    final private MasterAPI masterAPI;
-    final private SamResourceManager samResourceManager;
+    private final String nodeId;
+    private final MasterAPI masterAPI;
+    private final SamResourceManager samResourceManager;
 
     RemoteSePluginObserver(MasterAPI masterAPI, SamResourceManager samResourceManager,
             String nodeId) {
@@ -87,9 +87,9 @@ public class RemoteSePluginObserver implements ObservablePlugin.PluginObserver {
                      */
                     PoSelectionRequest poSelectionRequest = new PoSelectionRequest(
                             PoSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                                    .aidSelector(SeSelector.AidSelector.builder()
+                                    .aidSelector(AidSelector.builder()
                                             .aidToSelect(CalypsoClassicInfo.AID).build())
-                                    .invalidatedPo(PoSelector.InvalidatedPo.ACCEPT).build());
+                                    .invalidatedPo(InvalidatedPo.ACCEPT).build());
 
                     logger.info("{} Create a PoSelectionRequest", nodeId);
 

--- a/java/example/common/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoClassicTransactionEngine.java
+++ b/java/example/common/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoClassicTransactionEngine.java
@@ -281,9 +281,9 @@ public class CalypsoClassicTransactionEngine extends AbstractReaderObserverEngin
         /*
          * Add selection case 1: Fake AID1, protocol ISO, target rev 3
          */
-        seSelection.prepareSelection(new PoSelectionRequest(new PoSelector.Builder()
+        seSelection.prepareSelection(new PoSelectionRequest(PoSelector.builder()
                 .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                .aidSelector(new SeSelector.AidSelector.Builder().aidToSelect(poFakeAid1).build())
+                .aidSelector(SeSelector.AidSelector.builder().aidToSelect(poFakeAid1).build())
                 .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build()));
 
         /*
@@ -292,8 +292,8 @@ public class CalypsoClassicTransactionEngine extends AbstractReaderObserverEngin
          * addition of read commands to execute following the selection
          */
         PoSelectionRequest poSelectionRequestCalypsoAid = new PoSelectionRequest(
-                new PoSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                        .aidSelector(new SeSelector.AidSelector.Builder()
+                PoSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                        .aidSelector(SeSelector.AidSelector.builder()
                                 .aidToSelect(CalypsoClassicInfo.AID).build())
                         .invalidatedPo(PoSelector.InvalidatedPo.ACCEPT).build());
 
@@ -309,16 +309,16 @@ public class CalypsoClassicTransactionEngine extends AbstractReaderObserverEngin
         /*
          * Add selection case 3: Fake AID2, unspecified protocol, target rev 2 or 3
          */
-        seSelection.prepareSelection(new PoSelectionRequest(new PoSelector.Builder()
+        seSelection.prepareSelection(new PoSelectionRequest(PoSelector.builder()
                 .seProtocol(SeCommonProtocols.PROTOCOL_B_PRIME)
-                .aidSelector(new SeSelector.AidSelector.Builder().aidToSelect(poFakeAid2).build())
+                .aidSelector(SeSelector.AidSelector.builder().aidToSelect(poFakeAid2).build())
                 .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build()));
 
         /*
          * Add selection case 4: ATR selection, rev 1 atrregex
          */
         seSelection.prepareSelection(new PoSelectionRequest(
-                new PoSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_B_PRIME)
+                PoSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_B_PRIME)
                         .atrFilter(new PoSelector.AtrFilter(CalypsoClassicInfo.ATR_REV1_REGEX))
                         .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build()));
 

--- a/java/example/common/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoClassicTransactionEngine.java
+++ b/java/example/common/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoClassicTransactionEngine.java
@@ -281,21 +281,21 @@ public class CalypsoClassicTransactionEngine extends AbstractReaderObserverEngin
         /*
          * Add selection case 1: Fake AID1, protocol ISO, target rev 3
          */
-        seSelection.prepareSelection(
-                new PoSelectionRequest(new PoSelector(SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                        new PoSelector.AidSelector(new SeSelector.AidSelector.IsoAid(poFakeAid1)),
-                        PoSelector.InvalidatedPo.REJECT)));
+        seSelection.prepareSelection(new PoSelectionRequest(new PoSelector.Builder()
+                .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                .aidSelector(new SeSelector.AidSelector.Builder().aidToSelect(poFakeAid1).build())
+                .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build()));
 
         /*
          * Add selection case 2: Calypso application, protocol ISO, target rev 2 or 3
          *
          * addition of read commands to execute following the selection
          */
-        PoSelectionRequest poSelectionRequestCalypsoAid =
-                new PoSelectionRequest(new PoSelector(SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                        new PoSelector.AidSelector(
-                                new SeSelector.AidSelector.IsoAid(CalypsoClassicInfo.AID)),
-                        PoSelector.InvalidatedPo.ACCEPT));
+        PoSelectionRequest poSelectionRequestCalypsoAid = new PoSelectionRequest(
+                new PoSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                        .aidSelector(new SeSelector.AidSelector.Builder()
+                                .aidToSelect(CalypsoClassicInfo.AID).build())
+                        .invalidatedPo(PoSelector.InvalidatedPo.ACCEPT).build());
 
         poSelectionRequestCalypsoAid.prepareSelectFile(CalypsoClassicInfo.LID_DF_RT);
 
@@ -309,18 +309,18 @@ public class CalypsoClassicTransactionEngine extends AbstractReaderObserverEngin
         /*
          * Add selection case 3: Fake AID2, unspecified protocol, target rev 2 or 3
          */
-        seSelection.prepareSelection(
-                new PoSelectionRequest(new PoSelector(SeCommonProtocols.PROTOCOL_B_PRIME, null,
-                        new PoSelector.AidSelector(new SeSelector.AidSelector.IsoAid(poFakeAid2)),
-                        PoSelector.InvalidatedPo.REJECT)));
+        seSelection.prepareSelection(new PoSelectionRequest(new PoSelector.Builder()
+                .seProtocol(SeCommonProtocols.PROTOCOL_B_PRIME)
+                .aidSelector(new SeSelector.AidSelector.Builder().aidToSelect(poFakeAid2).build())
+                .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build()));
 
         /*
          * Add selection case 4: ATR selection, rev 1 atrregex
          */
-        seSelection.prepareSelection(
-                new PoSelectionRequest(new PoSelector(SeCommonProtocols.PROTOCOL_B_PRIME,
-                        new PoSelector.AtrFilter(CalypsoClassicInfo.ATR_REV1_REGEX), null,
-                        PoSelector.InvalidatedPo.REJECT)));
+        seSelection.prepareSelection(new PoSelectionRequest(
+                new PoSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_B_PRIME)
+                        .atrFilter(new PoSelector.AtrFilter(CalypsoClassicInfo.ATR_REV1_REGEX))
+                        .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build()));
 
         return seSelection.getSelectionOperation();
     }

--- a/java/example/common/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoClassicTransactionEngine.java
+++ b/java/example/common/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoClassicTransactionEngine.java
@@ -12,6 +12,7 @@
 package org.eclipse.keyple.example.common.calypso.pc.transaction;
 
 
+import static org.eclipse.keyple.calypso.transaction.PoSelector.*;
 import java.util.Map;
 import java.util.SortedMap;
 import org.eclipse.keyple.calypso.command.po.exception.CalypsoPoCommandException;
@@ -28,7 +29,6 @@ import org.eclipse.keyple.calypso.transaction.exception.CalypsoPoTransactionExce
 import org.eclipse.keyple.core.selection.SeSelection;
 import org.eclipse.keyple.core.seproxy.ChannelControl;
 import org.eclipse.keyple.core.seproxy.SeReader;
-import org.eclipse.keyple.core.seproxy.SeSelector;
 import org.eclipse.keyple.core.seproxy.event.AbstractDefaultSelectionsRequest;
 import org.eclipse.keyple.core.seproxy.event.AbstractDefaultSelectionsResponse;
 import org.eclipse.keyple.core.seproxy.exception.KeypleException;
@@ -281,21 +281,20 @@ public class CalypsoClassicTransactionEngine extends AbstractReaderObserverEngin
         /*
          * Add selection case 1: Fake AID1, protocol ISO, target rev 3
          */
-        seSelection.prepareSelection(new PoSelectionRequest(PoSelector.builder()
-                .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                .aidSelector(SeSelector.AidSelector.builder().aidToSelect(poFakeAid1).build())
-                .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build()));
+        seSelection.prepareSelection(new PoSelectionRequest(
+                PoSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                        .aidSelector(AidSelector.builder().aidToSelect(poFakeAid1).build())
+                        .invalidatedPo(InvalidatedPo.REJECT).build()));
 
         /*
          * Add selection case 2: Calypso application, protocol ISO, target rev 2 or 3
          *
          * addition of read commands to execute following the selection
          */
-        PoSelectionRequest poSelectionRequestCalypsoAid = new PoSelectionRequest(
-                PoSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                        .aidSelector(SeSelector.AidSelector.builder()
-                                .aidToSelect(CalypsoClassicInfo.AID).build())
-                        .invalidatedPo(PoSelector.InvalidatedPo.ACCEPT).build());
+        PoSelectionRequest poSelectionRequestCalypsoAid = new PoSelectionRequest(PoSelector
+                .builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                .aidSelector(AidSelector.builder().aidToSelect(CalypsoClassicInfo.AID).build())
+                .invalidatedPo(InvalidatedPo.ACCEPT).build());
 
         poSelectionRequestCalypsoAid.prepareSelectFile(CalypsoClassicInfo.LID_DF_RT);
 
@@ -309,10 +308,10 @@ public class CalypsoClassicTransactionEngine extends AbstractReaderObserverEngin
         /*
          * Add selection case 3: Fake AID2, unspecified protocol, target rev 2 or 3
          */
-        seSelection.prepareSelection(new PoSelectionRequest(PoSelector.builder()
-                .seProtocol(SeCommonProtocols.PROTOCOL_B_PRIME)
-                .aidSelector(SeSelector.AidSelector.builder().aidToSelect(poFakeAid2).build())
-                .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build()));
+        seSelection.prepareSelection(new PoSelectionRequest(
+                PoSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_B_PRIME)
+                        .aidSelector(AidSelector.builder().aidToSelect(poFakeAid2).build())
+                        .invalidatedPo(InvalidatedPo.REJECT).build()));
 
         /*
          * Add selection case 4: ATR selection, rev 1 atrregex
@@ -320,7 +319,7 @@ public class CalypsoClassicTransactionEngine extends AbstractReaderObserverEngin
         seSelection.prepareSelection(new PoSelectionRequest(
                 PoSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_B_PRIME)
                         .atrFilter(new PoSelector.AtrFilter(CalypsoClassicInfo.ATR_REV1_REGEX))
-                        .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build()));
+                        .invalidatedPo(InvalidatedPo.REJECT).build()));
 
         return seSelection.getSelectionOperation();
     }

--- a/java/example/common/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoUtilities.java
+++ b/java/example/common/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoUtilities.java
@@ -134,7 +134,8 @@ public final class CalypsoUtilities {
          */
         SeSelection samSelection = new SeSelection();
 
-        SamSelector samSelector = new SamSelector(C1, ".*");
+        SamSelector samSelector =
+                new SamSelector.Builder().samRevision(C1).serialNumber(".*").build();
 
         /* Prepare selector, ignore AbstractMatchingSe here */
         samSelection.prepareSelection(new SamSelectionRequest(samSelector));

--- a/java/example/common/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoUtilities.java
+++ b/java/example/common/src/main/java/org/eclipse/keyple/example/common/calypso/pc/transaction/CalypsoUtilities.java
@@ -134,8 +134,7 @@ public final class CalypsoUtilities {
          */
         SeSelection samSelection = new SeSelection();
 
-        SamSelector samSelector =
-                new SamSelector.Builder().samRevision(C1).serialNumber(".*").build();
+        SamSelector samSelector = SamSelector.builder().samRevision(C1).serialNumber(".*").build();
 
         /* Prepare selector, ignore AbstractMatchingSe here */
         samSelection.prepareSelection(new SamSelectionRequest(samSelector));

--- a/java/example/common/src/main/java/org/eclipse/keyple/example/common/generic/SeProtocolDetectionEngine.java
+++ b/java/example/common/src/main/java/org/eclipse/keyple/example/common/generic/SeProtocolDetectionEngine.java
@@ -12,6 +12,7 @@
 package org.eclipse.keyple.example.common.generic;
 
 
+import static org.eclipse.keyple.calypso.transaction.PoSelector.*;
 import org.eclipse.keyple.calypso.command.po.exception.CalypsoPoIllegalArgumentException;
 import org.eclipse.keyple.calypso.transaction.PoSelectionRequest;
 import org.eclipse.keyple.calypso.transaction.PoSelector;
@@ -64,11 +65,10 @@ public class SeProtocolDetectionEngine extends AbstractReaderObserverEngine {
                     byte SFI_T2Usage = (byte) 0x1A;
                     byte SFI_T2Environment = (byte) 0x14;
 
-                    PoSelectionRequest poSelectionRequest = new PoSelectionRequest(
-                            PoSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                                    .aidSelector(SeSelector.AidSelector.builder()
-                                            .aidToSelect(HoplinkAID).build())
-                                    .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
+                    PoSelectionRequest poSelectionRequest = new PoSelectionRequest(PoSelector
+                            .builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                            .aidSelector(AidSelector.builder().aidToSelect(HoplinkAID).build())
+                            .invalidatedPo(InvalidatedPo.REJECT).build());
 
                     poSelectionRequest.prepareReadRecordFile(SFI_T2Environment, 1);
 

--- a/java/example/common/src/main/java/org/eclipse/keyple/example/common/generic/SeProtocolDetectionEngine.java
+++ b/java/example/common/src/main/java/org/eclipse/keyple/example/common/generic/SeProtocolDetectionEngine.java
@@ -64,10 +64,9 @@ public class SeProtocolDetectionEngine extends AbstractReaderObserverEngine {
                     byte SFI_T2Usage = (byte) 0x1A;
                     byte SFI_T2Environment = (byte) 0x14;
 
-                    PoSelectionRequest poSelectionRequest =
-                            new PoSelectionRequest(new PoSelector.Builder()
-                                    .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                                    .aidSelector(new SeSelector.AidSelector.Builder()
+                    PoSelectionRequest poSelectionRequest = new PoSelectionRequest(
+                            PoSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                                    .aidSelector(SeSelector.AidSelector.builder()
                                             .aidToSelect(HoplinkAID).build())
                                     .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
 
@@ -86,9 +85,8 @@ public class SeProtocolDetectionEngine extends AbstractReaderObserverEngine {
                     break;
                 default:
                     /* Add a generic selector */
-                    seSelection
-                            .prepareSelection(new GenericSeSelectionRequest(new SeSelector.Builder()
-                                    .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                    seSelection.prepareSelection(new GenericSeSelectionRequest(
+                            SeSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
                                     .atrFilter(new SeSelector.AtrFilter(".*")).build()));
                     break;
             }

--- a/java/example/common/src/main/java/org/eclipse/keyple/example/common/generic/SeProtocolDetectionEngine.java
+++ b/java/example/common/src/main/java/org/eclipse/keyple/example/common/generic/SeProtocolDetectionEngine.java
@@ -64,11 +64,12 @@ public class SeProtocolDetectionEngine extends AbstractReaderObserverEngine {
                     byte SFI_T2Usage = (byte) 0x1A;
                     byte SFI_T2Environment = (byte) 0x14;
 
-                    PoSelectionRequest poSelectionRequest = new PoSelectionRequest(
-                            new PoSelector(SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                                    new PoSelector.AidSelector(
-                                            new PoSelector.AidSelector.IsoAid(HoplinkAID)),
-                                    PoSelector.InvalidatedPo.REJECT));
+                    PoSelectionRequest poSelectionRequest =
+                            new PoSelectionRequest(new PoSelector.Builder()
+                                    .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                                    .aidSelector(new SeSelector.AidSelector.Builder()
+                                            .aidToSelect(HoplinkAID).build())
+                                    .invalidatedPo(PoSelector.InvalidatedPo.REJECT).build());
 
                     poSelectionRequest.prepareReadRecordFile(SFI_T2Environment, 1);
 
@@ -85,9 +86,10 @@ public class SeProtocolDetectionEngine extends AbstractReaderObserverEngine {
                     break;
                 default:
                     /* Add a generic selector */
-                    seSelection.prepareSelection(new GenericSeSelectionRequest(
-                            new SeSelector(SeCommonProtocols.PROTOCOL_ISO14443_4,
-                                    new SeSelector.AtrFilter(".*"), null)));
+                    seSelection
+                            .prepareSelection(new GenericSeSelectionRequest(new SeSelector.Builder()
+                                    .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                                    .atrFilter(new SeSelector.AtrFilter(".*")).build()));
                     break;
             }
         }

--- a/java/example/generic/pc/UseCase1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/generic/pc/usecase1/ExplicitSelectionAid_Pcsc.java
+++ b/java/example/generic/pc/UseCase1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/generic/pc/usecase1/ExplicitSelectionAid_Pcsc.java
@@ -84,9 +84,9 @@ public class ExplicitSelectionAid_Pcsc {
             // Generic selection: configures a SeSelector with all the desired attributes to make
             // the selection and read additional information afterwards
             GenericSeSelectionRequest genericSeSelectionRequest = new GenericSeSelectionRequest(
-                    new SeSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                    SeSelector.builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
                             .aidSelector(
-                                    new SeSelector.AidSelector.Builder().aidToSelect(seAid).build())
+                                    SeSelector.AidSelector.builder().aidToSelect(seAid).build())
                             .build());
 
             // Add the selection case to the current selection (we could have added other cases

--- a/java/example/generic/pc/UseCase1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/generic/pc/usecase1/ExplicitSelectionAid_Pcsc.java
+++ b/java/example/generic/pc/UseCase1_ExplicitSelectionAid/src/main/java/org/eclipse/keyple/example/generic/pc/usecase1/ExplicitSelectionAid_Pcsc.java
@@ -84,9 +84,10 @@ public class ExplicitSelectionAid_Pcsc {
             // Generic selection: configures a SeSelector with all the desired attributes to make
             // the selection and read additional information afterwards
             GenericSeSelectionRequest genericSeSelectionRequest = new GenericSeSelectionRequest(
-                    new SeSelector(SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                            new SeSelector.AidSelector(new SeSelector.AidSelector.IsoAid(
-                                    ByteArrayUtil.fromHex(seAid)))));
+                    new SeSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                            .aidSelector(
+                                    new SeSelector.AidSelector.Builder().aidToSelect(seAid).build())
+                            .build());
 
             // Add the selection case to the current selection (we could have added other cases
             // here)

--- a/java/example/generic/pc/UseCase2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/generic/pc/usecase2/DefaultSelectionNotification_Pcsc.java
+++ b/java/example/generic/pc/UseCase2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/generic/pc/usecase2/DefaultSelectionNotification_Pcsc.java
@@ -93,11 +93,9 @@ public class DefaultSelectionNotification_Pcsc implements ReaderObserver {
 
         // Generic selection: configures a SeSelector with all the desired attributes to make the
         // selection
-        GenericSeSelectionRequest seSelector = new GenericSeSelectionRequest(
-                new SeSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                        .aidSelector(
-                                new SeSelector.AidSelector.Builder().aidToSelect(seAid).build())
-                        .build());
+        GenericSeSelectionRequest seSelector = new GenericSeSelectionRequest(SeSelector.builder()
+                .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                .aidSelector(SeSelector.AidSelector.builder().aidToSelect(seAid).build()).build());
 
         // Add the selection case to the current selection (we could have added other cases here)
         seSelection.prepareSelection(seSelector);

--- a/java/example/generic/pc/UseCase2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/generic/pc/usecase2/DefaultSelectionNotification_Pcsc.java
+++ b/java/example/generic/pc/UseCase2_DefaultSelectionNotification/src/main/java/org/eclipse/keyple/example/generic/pc/usecase2/DefaultSelectionNotification_Pcsc.java
@@ -24,7 +24,6 @@ import org.eclipse.keyple.core.seproxy.exception.KeypleException;
 import org.eclipse.keyple.core.seproxy.exception.KeyplePluginNotFoundException;
 import org.eclipse.keyple.core.seproxy.exception.KeypleReaderNotFoundException;
 import org.eclipse.keyple.core.seproxy.protocol.SeCommonProtocols;
-import org.eclipse.keyple.core.util.ByteArrayUtil;
 import org.eclipse.keyple.example.common.ReaderUtilities;
 import org.eclipse.keyple.example.common.generic.GenericSeSelectionRequest;
 import org.eclipse.keyple.plugin.pcsc.PcscPluginFactory;
@@ -94,10 +93,11 @@ public class DefaultSelectionNotification_Pcsc implements ReaderObserver {
 
         // Generic selection: configures a SeSelector with all the desired attributes to make the
         // selection
-        GenericSeSelectionRequest seSelector =
-                new GenericSeSelectionRequest(new SeSelector(SeCommonProtocols.PROTOCOL_ISO14443_4,
-                        null, new SeSelector.AidSelector(
-                                new SeSelector.AidSelector.IsoAid(ByteArrayUtil.fromHex(seAid)))));
+        GenericSeSelectionRequest seSelector = new GenericSeSelectionRequest(
+                new SeSelector.Builder().seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                        .aidSelector(
+                                new SeSelector.AidSelector.Builder().aidToSelect(seAid).build())
+                        .build());
 
         // Add the selection case to the current selection (we could have added other cases here)
         seSelection.prepareSelection(seSelector);

--- a/java/example/generic/pc/UseCase3_GroupedMultiSelection/src/main/java/org/eclipse/keyple/example/generic/pc/usecase3/GroupedMultiSelection_Pcsc.java
+++ b/java/example/generic/pc/UseCase3_GroupedMultiSelection/src/main/java/org/eclipse/keyple/example/generic/pc/usecase3/GroupedMultiSelection_Pcsc.java
@@ -63,9 +63,9 @@ public class GroupedMultiSelection_Pcsc {
             String seAidPrefix = "A000000404012509";
 
             // AID based selection (1st selection, later indexed 0)
-            seSelection.prepareSelection(new GenericSeSelectionRequest(new SeSelector.Builder()
+            seSelection.prepareSelection(new GenericSeSelectionRequest(SeSelector.builder()
                     .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                    .aidSelector(new SeSelector.AidSelector.Builder().aidToSelect(seAidPrefix)
+                    .aidSelector(SeSelector.AidSelector.builder().aidToSelect(seAidPrefix)
                             .fileOccurrence(SeSelector.AidSelector.FileOccurrence.FIRST)
                             .fileControlInformation(
                                     SeSelector.AidSelector.FileControlInformation.FCI)
@@ -73,9 +73,9 @@ public class GroupedMultiSelection_Pcsc {
                     .build()));
 
             // next selection (2nd selection, later indexed 1)
-            seSelection.prepareSelection(new GenericSeSelectionRequest(new SeSelector.Builder()
+            seSelection.prepareSelection(new GenericSeSelectionRequest(SeSelector.builder()
                     .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                    .aidSelector(new SeSelector.AidSelector.Builder().aidToSelect(seAidPrefix)
+                    .aidSelector(SeSelector.AidSelector.builder().aidToSelect(seAidPrefix)
                             .fileOccurrence(SeSelector.AidSelector.FileOccurrence.NEXT)
                             .fileControlInformation(
                                     SeSelector.AidSelector.FileControlInformation.FCI)
@@ -83,9 +83,9 @@ public class GroupedMultiSelection_Pcsc {
                     .build()));
 
             // next selection (3rd selection, later indexed 2)
-            seSelection.prepareSelection(new GenericSeSelectionRequest(new SeSelector.Builder()
+            seSelection.prepareSelection(new GenericSeSelectionRequest(SeSelector.builder()
                     .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                    .aidSelector(new SeSelector.AidSelector.Builder().aidToSelect(seAidPrefix)
+                    .aidSelector(SeSelector.AidSelector.builder().aidToSelect(seAidPrefix)
                             .fileOccurrence(SeSelector.AidSelector.FileOccurrence.NEXT)
                             .fileControlInformation(
                                     SeSelector.AidSelector.FileControlInformation.FCI)

--- a/java/example/generic/pc/UseCase3_GroupedMultiSelection/src/main/java/org/eclipse/keyple/example/generic/pc/usecase3/GroupedMultiSelection_Pcsc.java
+++ b/java/example/generic/pc/UseCase3_GroupedMultiSelection/src/main/java/org/eclipse/keyple/example/generic/pc/usecase3/GroupedMultiSelection_Pcsc.java
@@ -63,25 +63,34 @@ public class GroupedMultiSelection_Pcsc {
             String seAidPrefix = "A000000404012509";
 
             // AID based selection (1st selection, later indexed 0)
-            seSelection.prepareSelection(new GenericSeSelectionRequest(new SeSelector(
-                    SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                    new SeSelector.AidSelector(new SeSelector.AidSelector.IsoAid(seAidPrefix),
-                            SeSelector.AidSelector.FileOccurrence.FIRST,
-                            SeSelector.AidSelector.FileControlInformation.FCI))));
+            seSelection.prepareSelection(new GenericSeSelectionRequest(new SeSelector.Builder()
+                    .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                    .aidSelector(new SeSelector.AidSelector.Builder().aidToSelect(seAidPrefix)
+                            .fileOccurrence(SeSelector.AidSelector.FileOccurrence.FIRST)
+                            .fileControlInformation(
+                                    SeSelector.AidSelector.FileControlInformation.FCI)
+                            .build())
+                    .build()));
 
             // next selection (2nd selection, later indexed 1)
-            seSelection.prepareSelection(new GenericSeSelectionRequest(new SeSelector(
-                    SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                    new SeSelector.AidSelector(new SeSelector.AidSelector.IsoAid(seAidPrefix),
-                            SeSelector.AidSelector.FileOccurrence.NEXT,
-                            SeSelector.AidSelector.FileControlInformation.FCI))));
+            seSelection.prepareSelection(new GenericSeSelectionRequest(new SeSelector.Builder()
+                    .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                    .aidSelector(new SeSelector.AidSelector.Builder().aidToSelect(seAidPrefix)
+                            .fileOccurrence(SeSelector.AidSelector.FileOccurrence.NEXT)
+                            .fileControlInformation(
+                                    SeSelector.AidSelector.FileControlInformation.FCI)
+                            .build())
+                    .build()));
 
             // next selection (3rd selection, later indexed 2)
-            seSelection.prepareSelection(new GenericSeSelectionRequest(new SeSelector(
-                    SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                    new SeSelector.AidSelector(new SeSelector.AidSelector.IsoAid(seAidPrefix),
-                            SeSelector.AidSelector.FileOccurrence.NEXT,
-                            SeSelector.AidSelector.FileControlInformation.FCI))));
+            seSelection.prepareSelection(new GenericSeSelectionRequest(new SeSelector.Builder()
+                    .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                    .aidSelector(new SeSelector.AidSelector.Builder().aidToSelect(seAidPrefix)
+                            .fileOccurrence(SeSelector.AidSelector.FileOccurrence.NEXT)
+                            .fileControlInformation(
+                                    SeSelector.AidSelector.FileControlInformation.FCI)
+                            .build())
+                    .build()));
             // Actual SE communication: operate through a single request the SE selection
 
             SelectionsResult selectionsResult = seSelection.processExplicitSelection(seReader);

--- a/java/example/generic/pc/UseCase4_SequentialMultiSelection/src/main/java/org/eclipse/keyple/example/generic/pc/usecase4/SequentialMultiSelection_Pcsc.java
+++ b/java/example/generic/pc/UseCase4_SequentialMultiSelection/src/main/java/org/eclipse/keyple/example/generic/pc/usecase4/SequentialMultiSelection_Pcsc.java
@@ -86,12 +86,14 @@ public class SequentialMultiSelection_Pcsc {
 
             // AID based selection: get the first application occurrence matching the AID, keep the
             // physical channel open
-            seSelection.prepareSelection(new GenericSeSelectionRequest(new SeSelector(
-                    SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                    new SeSelector.AidSelector(
-                            new SeSelector.AidSelector.IsoAid(ByteArrayUtil.fromHex(seAidPrefix)),
-                            SeSelector.AidSelector.FileOccurrence.FIRST,
-                            SeSelector.AidSelector.FileControlInformation.FCI))));
+            seSelection.prepareSelection(new GenericSeSelectionRequest(new SeSelector.Builder()
+                    .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                    .aidSelector(new SeSelector.AidSelector.Builder().aidToSelect(seAidPrefix)
+                            .fileOccurrence(SeSelector.AidSelector.FileOccurrence.FIRST)
+                            .fileControlInformation(
+                                    SeSelector.AidSelector.FileControlInformation.FCI)
+                            .build())
+                    .build()));
 
             // Do the selection and display the result
             doAndAnalyseSelection(seReader, seSelection, 1);
@@ -101,12 +103,14 @@ public class SequentialMultiSelection_Pcsc {
             seSelection = new SeSelection(MultiSeRequestProcessing.FIRST_MATCH,
                     ChannelControl.CLOSE_AFTER);
 
-            seSelection.prepareSelection(new GenericSeSelectionRequest(new SeSelector(
-                    SeCommonProtocols.PROTOCOL_ISO14443_4, null,
-                    new SeSelector.AidSelector(
-                            new SeSelector.AidSelector.IsoAid(ByteArrayUtil.fromHex(seAidPrefix)),
-                            SeSelector.AidSelector.FileOccurrence.NEXT,
-                            SeSelector.AidSelector.FileControlInformation.FCI))));
+            seSelection.prepareSelection(new GenericSeSelectionRequest(new SeSelector.Builder()
+                    .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
+                    .aidSelector(new SeSelector.AidSelector.Builder().aidToSelect(seAidPrefix)
+                            .fileOccurrence(SeSelector.AidSelector.FileOccurrence.NEXT)
+                            .fileControlInformation(
+                                    SeSelector.AidSelector.FileControlInformation.FCI)
+                            .build())
+                    .build()));
 
             // Do the selection and display the result
             doAndAnalyseSelection(seReader, seSelection, 2);

--- a/java/example/generic/pc/UseCase4_SequentialMultiSelection/src/main/java/org/eclipse/keyple/example/generic/pc/usecase4/SequentialMultiSelection_Pcsc.java
+++ b/java/example/generic/pc/UseCase4_SequentialMultiSelection/src/main/java/org/eclipse/keyple/example/generic/pc/usecase4/SequentialMultiSelection_Pcsc.java
@@ -86,9 +86,9 @@ public class SequentialMultiSelection_Pcsc {
 
             // AID based selection: get the first application occurrence matching the AID, keep the
             // physical channel open
-            seSelection.prepareSelection(new GenericSeSelectionRequest(new SeSelector.Builder()
+            seSelection.prepareSelection(new GenericSeSelectionRequest(SeSelector.builder()
                     .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                    .aidSelector(new SeSelector.AidSelector.Builder().aidToSelect(seAidPrefix)
+                    .aidSelector(SeSelector.AidSelector.builder().aidToSelect(seAidPrefix)
                             .fileOccurrence(SeSelector.AidSelector.FileOccurrence.FIRST)
                             .fileControlInformation(
                                     SeSelector.AidSelector.FileControlInformation.FCI)
@@ -103,9 +103,9 @@ public class SequentialMultiSelection_Pcsc {
             seSelection = new SeSelection(MultiSeRequestProcessing.FIRST_MATCH,
                     ChannelControl.CLOSE_AFTER);
 
-            seSelection.prepareSelection(new GenericSeSelectionRequest(new SeSelector.Builder()
+            seSelection.prepareSelection(new GenericSeSelectionRequest(SeSelector.builder()
                     .seProtocol(SeCommonProtocols.PROTOCOL_ISO14443_4)
-                    .aidSelector(new SeSelector.AidSelector.Builder().aidToSelect(seAidPrefix)
+                    .aidSelector(SeSelector.AidSelector.builder().aidToSelect(seAidPrefix)
                             .fileOccurrence(SeSelector.AidSelector.FileOccurrence.NEXT)
                             .fileControlInformation(
                                     SeSelector.AidSelector.FileControlInformation.FCI)
@@ -116,6 +116,7 @@ public class SequentialMultiSelection_Pcsc {
             doAndAnalyseSelection(seReader, seSelection, 2);
 
         } else {
+
             logger.error("No SE were detected.");
         }
         System.exit(0);


### PR DESCRIPTION
- remove IsoAid inner class from SeSelector.AidSelector
- apply the builder pattern to all selectors (SeSelector, PoSelector, SamSelector, SamIdentifier)
- update unit tests and examples