### PR TITLE
fix: KEYP-290 correction of an NPE generated at the opening of the session in rev 2.4

### DIFF
--- a/java/component/keyple-calypso/src/main/java/org/eclipse/keyple/calypso/command/po/parser/security/OpenSession24RespPars.java
+++ b/java/component/keyple-calypso/src/main/java/org/eclipse/keyple/calypso/command/po/parser/security/OpenSession24RespPars.java
@@ -58,11 +58,12 @@ public final class OpenSession24RespPars extends AbstractOpenSessionRespPars {
          * </ul>
          */
 
-        byte[] data = null;
+        byte[] data;
 
         switch (apduResponseData.length) {
             case 5:
                 previousSessionRatified = true;
+                data = new byte[0];
                 break;
             case 34:
                 previousSessionRatified = true;
@@ -70,6 +71,7 @@ public final class OpenSession24RespPars extends AbstractOpenSessionRespPars {
                 break;
             case 7:
                 previousSessionRatified = false;
+                data = new byte[0];
                 break;
             case 36:
                 previousSessionRatified = false;


### PR DESCRIPTION
- when parsing the answer to the open secure session command an empty array is created for rev 2.4 if no data is available (no record read)