### PR TITLE
fix: KEYP-293 add utf-8 encoding setting for Javadoc

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -83,7 +83,6 @@ task javadoc(type: org.jetbrains.dokka.gradle.DokkaTask) {
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
-    javadoc.options.encoding = 'UTF-8'
     from dokka.outputDirectory
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -83,6 +83,7 @@ task javadoc(type: org.jetbrains.dokka.gradle.DokkaTask) {
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
+    javadoc.options.encoding = 'UTF-8'
     from dokka.outputDirectory
 }
 

--- a/java/component/keyple-calypso/build.gradle
+++ b/java/component/keyple-calypso/build.gradle
@@ -41,6 +41,7 @@ task sourcesJar(type: Jar, dependsOn : classes) {
 //generate javadoc jar
 task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
+    javadoc.options.encoding = 'UTF-8'
     from javadoc.destinationDir
 }
 

--- a/java/component/keyple-core/build.gradle
+++ b/java/component/keyple-core/build.gradle
@@ -60,6 +60,7 @@ task sourcesJar(type: Jar, dependsOn : classes) {
 //generate javadoc jar
 task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
+    javadoc.options.encoding = 'UTF-8'
     from javadoc.destinationDir
 }
 

--- a/java/component/keyple-plugin/pcsc/build.gradle
+++ b/java/component/keyple-plugin/pcsc/build.gradle
@@ -40,6 +40,7 @@ task sourcesJar(type: Jar, dependsOn : classes) {
 //generate javadoc jar
 task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
+    javadoc.options.encoding = 'UTF-8'
     from javadoc.destinationDir
 }
 

--- a/java/component/keyple-plugin/remotese/build.gradle
+++ b/java/component/keyple-plugin/remotese/build.gradle
@@ -40,6 +40,7 @@ task sourcesJar(type: Jar, dependsOn : classes) {
 //generate javadoc jar
 task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
+    javadoc.options.encoding = 'UTF-8'
     from javadoc.destinationDir
 }
 

--- a/java/component/keyple-plugin/stub/build.gradle
+++ b/java/component/keyple-plugin/stub/build.gradle
@@ -41,6 +41,7 @@ task sourcesJar(type: Jar, dependsOn : classes) {
 //generate javadoc jar
 task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
+    javadoc.options.encoding = 'UTF-8'
     from javadoc.destinationDir
 }
 


### PR DESCRIPTION
- build.gradle, task javadocJar